### PR TITLE
Automatically deploy master branch to demo server

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,3 +3,8 @@ machine:
     version: 4.2.2
   environment:
     TEST_DATABASE_URL: postgres://ubuntu@localhost/circle_test
+deployment:
+  demo:
+    branch: master
+    heroku:
+      appname: fj16-reki-demo


### PR DESCRIPTION
Should now work.

It currently deploys here: http://fj16-reki-demo.herokuapp.com/
