### PR TITLE
Move webpack-dev-server and httpproxy to normal depenencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "errorhandler": "^1.4.2",
     "file-loader": "^0.8.5",
     "history": "^1.17.0",
+    "http-proxy": "^1.12.0",
     "loopback": "^2.25.0",
     "loopback-boot": "^2.14.2",
     "loopback-connector-postgresql": "^2.4.0",
@@ -46,7 +47,8 @@
     "style-loader": "^0.13.0",
     "uglify-js": "^2.6.1",
     "url-loader": "^0.5.7",
-    "webpack": "^1.12.9"
+    "webpack": "^1.12.9",
+    "webpack-dev-server": "^1.14.0"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",
@@ -55,9 +57,7 @@
     "commander": "^2.9.0",
     "eslint": "^1.10.2",
     "eslint-plugin-react": "^3.11.2",
-    "http-proxy": "^1.12.0",
-    "mocha": "^2.3.4",
-    "webpack-dev-server": "^1.14.0"
+    "mocha": "^2.3.4"
   },
   "engines": {
     "node": "~4.2.2",


### PR DESCRIPTION
Workaround for Heroku crashes.
The move to the ES6 import syntax seems to have caused problems. It
doesn't seem to support trying to load modules that are not available,
which caused problems with these two modules that were dev-dependencies.
