### PR TITLE
Fix a couple of bugs in RestfulResource

### DIFF
--- a/src/client/utils/RestfulResource.js
+++ b/src/client/utils/RestfulResource.js
@@ -45,13 +45,13 @@ export function getRestfulResource(request) {
       return request.put(this.path(id))
         .accept('application/json')
         .send(obj)
-        .then(this.handleRequest);
+        .then(this.handleResponse);
     }
 
     del(id) {
       return request.del(this.path(id))
         .accept('application/json')
-        .then(this.handleRequest);
+        .then(this.handleResponse);
     }
 
     raw(method, path, body) {
@@ -60,9 +60,9 @@ export function getRestfulResource(request) {
 
       if (body) {
         req = req.send(body);
-
-        return req.then(this.handleRequest);
       }
+
+      return req.then(this.handleResponse);
     }
   }
 


### PR DESCRIPTION
I had typoed the handleResponse function as handleRequest in a couple of
places, and placed the return in the raw function in the wrong place
resulting in the function not returning at all if no body was supplied.
