### PR TITLE
Muuttaa leiriläislistan linkin tyypiksi IndexLinkin, jotta se ei näkyisi valittuna detailisivulla

### DIFF
--- a/src/client/components/App.jsx
+++ b/src/client/components/App.jsx
@@ -15,7 +15,7 @@ export function getApp() {
               </Navbar.Brand>
             </Navbar.Header>
             <Nav pullRight>
-              <NavLinkItem to="/participants">Leiriläiset</NavLinkItem>
+              <NavLinkItem to="/participants" isIndexLink>Leiriläiset</NavLinkItem>
             </Nav>
           </Navbar>
           <Grid>

--- a/src/client/components/NavLinkItem.jsx
+++ b/src/client/components/NavLinkItem.jsx
@@ -1,25 +1,38 @@
 import React from 'react';
 import { NavItem } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer, IndexLinkContainer } from 'react-router-bootstrap';
 
 export class NavLinkItem extends React.Component {
   render() {
     const {
       to,
       children,
+      isIndexLink,
     } = this.props;
 
-    return (
-      <LinkContainer to={ to }>
-        <NavItem>
-          { children }
-        </NavItem>
-      </LinkContainer>
+    const navItem = (
+      <NavItem>
+        { children }
+      </NavItem>
     );
+
+    if (isIndexLink) {
+      return (
+        <IndexLinkContainer to={ to }>
+          { navItem }
+        </IndexLinkContainer>
+      );
+    } else {
+      return (
+        <LinkContainer to={ to }>
+          { navItem }
+        </LinkContainer>
+      );
+    }
   }
 }
 
-const { oneOfType, string, object, node } = React.PropTypes;
+const { oneOfType, string, object, node, bool } = React.PropTypes;
 
 NavLinkItem.propTypes = {
   to: oneOfType([
@@ -27,4 +40,9 @@ NavLinkItem.propTypes = {
     object,
   ]),
   children: node,
+  isIndexLink: bool,
+};
+
+NavLinkItem.defaultProps = {
+  isIndexLink: false,
 };


### PR DESCRIPTION
An IndexLink/IndexLinkContainer (to '/participants' for example) will
not show up as active when a subpage is shown (for example
'/participants/1'), whereas the Link/LinkContainer will show up as
active for both.
