### PR TITLE
Fixed user table overflow bug

### DIFF
--- a/src/client/components/RegistryUserListPage/UserManagementPage.jsx
+++ b/src/client/components/RegistryUserListPage/UserManagementPage.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { RegistryUserTable } from './RegistryUserTable';
-import { Grid, Row } from 'react-bootstrap';
 
 export function getUserManagementPage(registryUserStore, registryUserActions) {
   class UserManagementPage extends React.Component {
@@ -27,14 +26,10 @@ export function getUserManagementPage(registryUserStore, registryUserActions) {
 
     render() {
       return (
-        <Grid>
-          <Row>
-            <h1>Käyttäjät</h1>
-          </Row>
-          <Row>
-            <RegistryUserTable registryUsers={ this.state.registryUsers }/>
-          </Row>
-        </Grid>
+        <div>
+          <h1>Käyttäjät</h1>
+          <RegistryUserTable registryUsers={ this.state.registryUsers }/>
+        </div>
       );
     }
   }


### PR DESCRIPTION
Käyttäjälistausken taulukko vuotaa sivun yli. Korjattu poistamalla "tuplagridi" sivulta.

![screenshot 2016-05-28 12 47 33](https://cloud.githubusercontent.com/assets/1097009/15626645/a95dc810-24d2-11e6-8dd2-7e9d345a6541.png)
