### PR TITLE
Fix login prompt that errornously showed on reloads

### DIFF
--- a/src/client/actions/RegistryUserActions.js
+++ b/src/client/actions/RegistryUserActions.js
@@ -23,6 +23,10 @@ export function getRegistryUserActions(alt, registryUserResource) {
       return error;
     }
 
+    updateLoginStatus(loggedIn) {
+      return loggedIn;
+    }
+
     loadCurrentUser(id) {
       return dispatch => {
         dispatch();

--- a/src/client/components/ParticipantListPage/containers/CampGroupFilterContainer.jsx
+++ b/src/client/components/ParticipantListPage/containers/CampGroupFilterContainer.jsx
@@ -12,7 +12,7 @@ export function getCampGroupFilterContainer(participantStore, participantActions
     }
 
     componentWillMount() {
-      participantActions.loadCampGroups();
+      participantActions.loadCampGroups.defer();
     }
 
     componentDidMount() {

--- a/src/client/components/ParticipantListPage/containers/LocalGroupFilterContainer.jsx
+++ b/src/client/components/ParticipantListPage/containers/LocalGroupFilterContainer.jsx
@@ -12,7 +12,7 @@ export function getLocalGroupFilterContainer(participantStore, participantAction
     }
 
     componentWillMount() {
-      participantActions.loadLocalGroups();
+      participantActions.loadLocalGroups.defer();
     }
 
     componentDidMount() {

--- a/src/client/components/ParticipantListPage/containers/ParticipantCountUpdater.jsx
+++ b/src/client/components/ParticipantListPage/containers/ParticipantCountUpdater.jsx
@@ -8,7 +8,7 @@ export function getParticipantCountUpdater(participantActions) {
     }
 
     render() {
-      participantActions.loadParticipantCount(this.props.filter);
+      participantActions.loadParticipantCount.defer(this.props.filter);
       return null;
     }
   }

--- a/src/client/components/ParticipantListPage/containers/ParticipantListUpdater.jsx
+++ b/src/client/components/ParticipantListPage/containers/ParticipantListUpdater.jsx
@@ -11,7 +11,7 @@ export function getParticipantListUpdater(participantActions) {
         filter,
       } = this.props;
 
-      participantActions.loadParticipantList(offset, limit, order, filter);
+      participantActions.loadParticipantList.defer(offset, limit, order, filter);
     }
 
     shouldComponentUpdate(nextProps, nextState) {

--- a/src/client/main.jsx
+++ b/src/client/main.jsx
@@ -54,9 +54,11 @@ const accessTokenValid = accessToken && accessToken.userId && accessToken.ttl > 
 
 if (accessTokenValid) {
   registryUserActions.loadCurrentUser(accessToken.userId);
+  registryUserActions.updateLoginStatus(true);
 } else {
   Cookie.remove('accessToken');
   registryUserActions.loadCurrentUser();
+  registryUserActions.updateLoginStatus(false);
 }
 
 const routes = (

--- a/src/client/stores/RegistryUserStore.js
+++ b/src/client/stores/RegistryUserStore.js
@@ -3,10 +3,12 @@ export function getRegistryUserStore(alt, RegistryUserActions) {
     constructor() {
       this.registryUsers = [ ];
       this.currentUser = null;
+      this.loggedIn = false;
 
       this.bindListeners({
         handleRegistryUserListUpdated: RegistryUserActions.REGISTRY_USER_LIST_UPDATED,
         handleCurrentUserUpdated: RegistryUserActions.CURRENT_USER_UPDATED,
+        handleLoginStatusUpdated: RegistryUserActions.UPDATE_LOGIN_STATUS,
       });
     }
 
@@ -16,6 +18,10 @@ export function getRegistryUserStore(alt, RegistryUserActions) {
 
     handleCurrentUserUpdated(newCurrentUser) {
       this.currentUser = newCurrentUser;
+    }
+
+    handleLoginStatusUpdated(loggedIn) {
+      this.loggedIn = loggedIn;
     }
   }
 

--- a/src/client/utils/restrictComponent.jsx
+++ b/src/client/utils/restrictComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { pureShouldComponentUpdate } from './pureShouldComponentUpdate';
 
 class EmptyComponent extends React.Component {
   render() {
@@ -12,7 +13,13 @@ export function restrictComponent(UserStore, Component, AlternativeComponent) {
   class RestrictedComponent extends React.Component {
     constructor(props) {
       super(props);
+
+      this.selectState = this.selectState.bind(this);
+      this.onChange = this.onChange.bind(this);
+
       this.state = this.selectState(UserStore.getState());
+
+      this.shouldComponentUpdate = pureShouldComponentUpdate.bind(this);
     }
 
     componentDidMount() {
@@ -32,7 +39,7 @@ export function restrictComponent(UserStore, Component, AlternativeComponent) {
     }
 
     render() {
-      if (this.state.currentUser) {
+      if (this.state.loggedIn) {
         return (<Component { ...this.props }/>);
       } else {
         return (<AlternativeComponent />);


### PR DESCRIPTION
Aikasemmin jos oli kirjautuneena sisään ja latasi sivun uudelleen (f5) niin reki näytti pyynnön kirjautua sisään. Käyttäjä oli tosiasiassa yhä kirjautuneena, mutta this-ongelman takia tieto ei päivittynyt näkyviin. Nyt se tulee heti ja oikein
