### PR TITLE
Use OpenShift database url in production, if DATABASE_URL is not set

### DIFF
--- a/src/server/datasources.local.js
+++ b/src/server/datasources.local.js
@@ -1,5 +1,5 @@
 module.exports = {
   'db': {
-    'url': process.env.DATABASE_URL,
+    'url': process.env.DATABASE_URL || process.env.OPENSHIFT_POSTGRESQL_DB_URL,
   },
 };


### PR DESCRIPTION
This is needed to work in OpenShift
