### PR TITLE
Bugfix / eventEmitter raise maxlisteners

### DIFF
--- a/scripts/seed-database.js
+++ b/scripts/seed-database.js
@@ -1,8 +1,10 @@
 import path from 'path';
 import Promise from 'bluebird';
-
+import EventEmitter from 'events';
 import app from '../src/server/server';
 import { getModelCreationList, getFixtureCreationList } from '../src/common/models-list';
+
+EventEmitter.prototype._maxListeners = 20;
 
 function getFixtures(modelName) {
   return Promise.try(() => require(path.resolve(__dirname, `../src/common/fixtures/${modelName}`)));

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -2,9 +2,6 @@ import app from '../../src/server/server';
 import Promise from 'bluebird';
 import _ from 'lodash';
 import { expect } from 'chai';
-import EventEmitter from 'events';
-
-EventEmitter.prototype._maxListeners = 20;
 
 export function loginUser(username, userpass) {
   userpass = userpass || 'salasana';


### PR DESCRIPTION
```
(node) warning: possible EventEmitter memory leak detected. 11 connected listeners added. Use emitter.setMaxListeners() to increase limit.
```

Fixed by increasing limit to 20 on tests.
