### PR TITLE
Fix LoopBack warning about user session invalidation

### DIFF
--- a/src/server/config.json
+++ b/src/server/config.json
@@ -22,5 +22,6 @@
       "disableStackTrace": false
     }
   },
-  "legacyExplorer": false
+  "legacyExplorer": false,
+  "logoutSessionsOnSensitiveChanges": true
 }


### PR DESCRIPTION
LoopBack has started giving the following warning:

> The user model "RegistryUser" is attached to an application that does not specify
whether other sessions should be invalidated when a password or
an email has changed. Session invalidation is important for security
reasons as it allows users to recover from various account breach
situations. [...]

Added setting to enable session invalidation in order to remove the warning.