### PR TITLE
Fix bug that caused any edits done on the participant page to fail

### DIFF
--- a/src/client/actions/ParticipantActions.js
+++ b/src/client/actions/ParticipantActions.js
@@ -73,10 +73,10 @@ export function getParticipantActions(alt, participantResource, errorActions) {
       return dispatch => {
         dispatch();
         participantResource.raw('post', 'massAssign', {
-          body: { ids: participantId, fieldName: property, newValue: value } })
+          body: { ids: [ participantId ], fieldName: property, newValue: value } })
           .then(participants => {
             if (property === 'presence') {
-              this.fetchParticipantByIdWithPresenceHistory(participants.result[0].participantId);
+              this.fetchParticipantByIdWithPresenceHistory(participants[0].participantId);
             }
             this.participantPropertyUpdated(property, participants);
           }, err => errorActions.error(err, 'Osallistujan tallennus epäonnistui'));
@@ -86,7 +86,7 @@ export function getParticipantActions(alt, participantResource, errorActions) {
     participantPropertyUpdated(property, participants) {
       return {
         property: property,
-        newValue: participants.result[0][property],
+        newValue: participants[0][property],
       };
     }
 

--- a/test/functional/massedit-endpoint.test.js
+++ b/test/functional/massedit-endpoint.test.js
@@ -104,6 +104,10 @@ describe('Participant mass edit endpoint test', () => {
   it('Should update whitelisted fields', () =>
     postInstanceToDb('participants/massAssign', { ids: [ 1,2 ], newValue: inCamp, fieldName: 'presence' }, accessToken)
       .expect(200)
+      .expect(result => {
+        expect(result.body).to.be.an('array').with.length(2);
+        expect(result.body[0]).to.have.property('firstName', 'Teemu');
+      })
       .then( () => queryParticipants(accessToken)
       .then( res => expectParticipantInCampValues([ inCamp, inCamp, tmpLeftCamp ], res.body) )
    )


### PR DESCRIPTION
Problem was that the behavior of the massAssign backend changed a bit when it was migrated from LoopBack REST to Express. Previously, LoopBack automatically wrapped the ids parameter to an array if it was an integer and the current endpoint doesn't. Also, LoopBack wrapped the result of massAssign in a "result" object, which also no longer happens. Now the frontend has been updated to use the proper conventions of the backend.

The functional tests didn't catch this since 1) they were never tested with non-array ids parameter 2) they never tested the return value of massAssign. We no longer need to support integer arguments for ids, which fixes (1). I also added some tests for the shape of massAssign's return value, preventing (2) from happening again. In the long run we should improve end-to-end test coverage.