### PR TITLE
Update engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,8 @@
     "webpack-cli": "^3.0.1"
   },
   "engines": {
-    "node": "~8.0.0",
-    "npm": "~5.0.0"
+    "node": "8.11.x",
+    "npm": "5.6.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The previously used engines would not install all required packages on
heroku for some reason (esp. 'options' package required by 'sse').