### PR TITLE
Remove authentication implementation details from tests

### DIFF
--- a/test/functional/acl.test.js
+++ b/test/functional/acl.test.js
@@ -211,7 +211,6 @@ describe('http api access control', () => {
         testUtils.expectStatus(res.status, UNAUTHORIZED);
       });
 
-      //Use separate access token for logout because the access token used here will cease working on logout
       it('logout: OK', () => post('/api/registryusers/logout', null, []).expect(NO_CONTENT));
 
       it('block user: UNAUTHORIZED', () => post(`/api/registryusers/${otherUserId}/block`, null, []).expect(UNAUTHORIZED));
@@ -227,7 +226,6 @@ describe('http api access control', () => {
         testUtils.expectStatus(res.status, OK);
       });
 
-      //Use separate access token for logout because the access token used here will cease working on logout
       it('logout: OK', () => post('/api/registryusers/logout', null, ['registryUser']).expect(NO_CONTENT));
 
       it('block user: UNAUTHORIZED', () => post(`/api/registryusers/${otherUserId}/block`, null, ['registryUser']).expect(UNAUTHORIZED));
@@ -243,7 +241,6 @@ describe('http api access control', () => {
         testUtils.expectStatus(res.status, OK);
       });
 
-      //Use separate access token for logout because the access token used here will cease working on logout
       it('logout: OK', () => post('/api/registryusers/logout', null, ['registryAdmin']).expect(NO_CONTENT));
 
       it('block user: NO_CONTENT', () => post(`/api/registryusers/${otherUserId}/block`, null, ['registryAdmin']).expect(NO_CONTENT));

--- a/test/functional/acl.test.js
+++ b/test/functional/acl.test.js
@@ -9,11 +9,13 @@ import _ from 'lodash';
 const expect = chai.expect;
 chai.use(chaiAsPromised);
 
+const createUser = testUtils.createUserWithRoles;
+
 function get(endpoint, roles) {
   return {
     expect: async code => {
       if (roles) {
-        const res = await testUtils.getWithRoles(endpoint, roles);
+        const res = await testUtils.getWithUser(endpoint, await createUser(roles));
         testUtils.expectStatus(res.status, code);
       } else {
         await request(app).get(endpoint).expect(code);
@@ -26,7 +28,7 @@ function post(endpoint, data, roles) {
   return {
     expect: async code => {
       if (roles) {
-        const res = await testUtils.postWithRoles(endpoint, roles, data);
+        const res = await testUtils.postWithUser(endpoint, await createUser(roles), data);
         testUtils.expectStatus(res.status, code);
       } else {
         await request(app).post(endpoint).send(data).expect(code);
@@ -39,7 +41,7 @@ function del(endpoint, roles) {
   return {
     expect: async code => {
       if (roles) {
-        const res = await testUtils.deleteWithRoles(endpoint, roles);
+        const res = await testUtils.deleteWithUser(endpoint, await createUser(roles));
         testUtils.expectStatus(res.status, code);
       } else {
         await request(app).del(endpoint).expect(code);

--- a/test/functional/audit-event.test.js
+++ b/test/functional/audit-event.test.js
@@ -43,7 +43,8 @@ describe('Audit Event', () => {
   }
 
   it('should create audit event when finding registryusers', async () => {
-    const response = await testUtils.getWithRoles('/api/registryusers', [ 'registryAdmin' ]);
+    const user = await testUtils.createUserWithRoles(['registryAdmin']);
+    const response = await testUtils.getWithUser('/api/registryusers', user);
     testUtils.expectStatus(response.status, 200);
     await expectAuditEventToEventuallyExist({
       'eventType': 'find',
@@ -52,7 +53,8 @@ describe('Audit Event', () => {
   });
 
   it('should create audit event when finding participant', async () => {
-    const response = await testUtils.getWithRoles('/api/participants/42', [ 'registryUser' ]);
+    const user = await testUtils.createUserWithRoles(['registryUser']);
+    const response = await testUtils.getWithUser('/api/participants/42', user);
     testUtils.expectStatus(response.status, 200);
     await expectAuditEventToEventuallyExist({
       'eventType': 'find',

--- a/test/functional/config.test.js
+++ b/test/functional/config.test.js
@@ -13,10 +13,6 @@ describe('Config API endpoint', () => {
     testUtils.expectStatus(response.status, 200);
   });
 
-  afterEach(async () => {
-    await testUtils.deleteFixturesIfExist('RegistryUser');
-  });
-
   it('has participant fields', async () => {
     expect(response.body).to.have.property('fields');
     expect(response.body.fields).to.be.an('array');

--- a/test/functional/config.test.js
+++ b/test/functional/config.test.js
@@ -1,16 +1,22 @@
 import chai from 'chai';
-import * as testUtils from '../utils/test-utils';
+import {
+  createUserWithRoles as createUser,
+  getWithUser,
+  expectStatus,
+} from '../utils/test-utils';
 import { resetDatabase } from '../../scripts/seed-database';
 
 const expect = chai.expect;
 
 describe('Config API endpoint', () => {
   let response;
-  before(resetDatabase);
+
+  after(resetDatabase);
 
   beforeEach(async() => {
-    response = await testUtils.getWithRoles('/api/config', [ 'registryUser' ]);
-    testUtils.expectStatus(response.status, 200);
+    const user = await createUser(['registryUser']);
+    response = await getWithUser('/api/config', user);
+    expectStatus(response.status, 200);
   });
 
   it('has participant fields', async () => {

--- a/test/functional/config.test.js
+++ b/test/functional/config.test.js
@@ -1,91 +1,62 @@
-import app from '../../src/server/server';
-import request from 'supertest';
 import chai from 'chai';
 import * as testUtils from '../utils/test-utils';
 import { resetDatabase } from '../../scripts/seed-database';
 
 const expect = chai.expect;
 
-describe('Config api endpoint', () => {
-
-  let accessToken = null;
-
+describe('Config API endpoint', () => {
+  let response;
   before(resetDatabase);
 
-  beforeEach(async () => {
-    accessToken = await testUtils.createUserAndGetAccessToken(['registryUser']);
-    accessToken = accessToken.id;
+  beforeEach(async() => {
+    response = await testUtils.getWithRoles('/api/config', [ 'registryUser' ]);
+    testUtils.expectStatus(response.status, 200);
   });
 
   afterEach(async () => {
     await testUtils.deleteFixturesIfExist('RegistryUser');
   });
 
-  it('has participant fields', async () =>
-    await request(app)
-    .get(`/api/config?access_token=${accessToken}`)
-    .expect(200)
-    .expect(res => {
-      expect(res.body).to.have.property('fields');
-      expect(res.body.fields).to.be.an('array');
-    })
-  );
+  it('has participant fields', async () => {
+    expect(response.body).to.have.property('fields');
+    expect(response.body.fields).to.be.an('array');
+  });
 
   it('has participants allwaysIncudedFields', async () =>
-    await request(app)
-    .get(`/api/config?access_token=${accessToken}`)
-    .expect(res => {
-      expect(res.body.fields).to.deep.include({
-        name: 'presence',
-        type: 'mandatory_field',
-        dataType: 'integer',
-        nullable: true,
-      });
+    expect(response.body.fields).to.deep.include({
+      name: 'presence',
+      type: 'mandatory_field',
+      dataType: 'integer',
+      nullable: true,
     })
   );
 
   it('participant has custom fields from config', async () =>
-    await request(app)
-    .get(`/api/config?access_token=${accessToken}`)
-    .expect(res => {
-      expect(res.body.fields).to.deep.include({
-        name: 'nickname',
-        type: 'participant_field',
-        dataType: 'string',
-        nullable: true,
-      });
+    expect(response.body.fields).to.deep.include({
+      name: 'nickname',
+      type: 'participant_field',
+      dataType: 'string',
+      nullable: true,
     })
   );
 
-  it('returns fields to show in participant table', async () =>
-    await request(app)
-    .get(`/api/config?access_token=${accessToken}`)
-    .expect(res => {
-      expect(res.body.tableFields).to.be.an('array');
-      expect(res.body.tableFields).to.include('firstName');
-    })
-  );
+  it('returns fields to show in participant table', async () => {
+    expect(response.body.tableFields).to.be.an('array');
+    expect(response.body.tableFields).to.include('firstName');
+  });
 
-  it('returns detail page fields', async () =>
-    await request(app)
-    .get(`/api/config?access_token=${accessToken}`)
-    .expect(res => {
-      expect(res.body.detailsPageFields).to.be.an('array');
-      expect(res.body.detailsPageFields[0]).to.have.property('groupTitle', 'Yhteystiedot');
-      expect(res.body.detailsPageFields[0]).to.have.property('fields');
-    })
-  );
+  it('returns detail page fields', async () => {
+    expect(response.body.detailsPageFields).to.be.an('array');
+    expect(response.body.detailsPageFields[0]).to.have.property('groupTitle', 'Yhteystiedot');
+    expect(response.body.detailsPageFields[0]).to.have.property('fields');
+  });
 
-  it('returns filters', async () =>
-    await request(app)
-    .get(`/api/config?access_token=${accessToken}`)
-    .expect(res => {
-      expect(res.body.filters).to.be.an('array');
-      expect(res.body.filters).to.deep.include({
-        field: 'ageGroup',
-        primary: true,
-      });
-    })
-  );
+  it('returns filters', async () => {
+    expect(response.body.filters).to.be.an('array');
+    expect(response.body.filters).to.deep.include({
+      field: 'ageGroup',
+      primary: true,
+    });
+  });
 
 });

--- a/test/functional/date-search.test.js
+++ b/test/functional/date-search.test.js
@@ -71,9 +71,10 @@ describe('Date search', () => {
   after(resetDatabase);
 
   async function queryParticipants(filter) {
-    const res = await testUtils.getWithRoles(
+    const user = await testUtils.createUserWithRoles(['registryUser']);
+    const res = await testUtils.getWithUser(
       `/api/participants/?filter={"where":${JSON.stringify(filter)},"skip":0,"limit":20}`,
-      ['registryUser']
+      user,
     );
     testUtils.expectStatus(res.status, 200);
     return res;

--- a/test/functional/massedit-endpoint.test.js
+++ b/test/functional/massedit-endpoint.test.js
@@ -1,6 +1,5 @@
-import app from '../../src/server/server';
+import { models } from '../../src/server/models';
 import _ from 'lodash';
-import request from 'supertest';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import * as testUtils from '../utils/test-utils';
@@ -10,8 +9,6 @@ const expect = chai.expect;
 chai.use(chaiAsPromised);
 
 describe('Participant mass edit endpoint test', () => {
-  let accessToken;
-
   const inCamp = 3;
   const tmpLeftCamp = 2;
   const leftCamp = 1;
@@ -64,65 +61,39 @@ describe('Participant mass edit endpoint test', () => {
     },
   ];
 
-  const adminUserFixture = {
-    'username': 'testAdmin',
-    'memberNumber': '7654321',
-    'email': 'testi@adm.in',
-    'password': 'salasana',
-    'phone': 'n/a',
-    'firstName': 'Testi',
-    'lastName': 'Admin',
-  };
+  beforeEach(async() => {
+    await resetDatabase();
+    await testUtils.createFixtureSequelize('Participant', testParticipants);
+  });
 
-  beforeEach(() =>
-    resetDatabase()
-      .then(() => testUtils.createUserWithRoles(['registryUser', 'registryAdmin'], adminUserFixture))
-      .then(() => testUtils.loginUser(adminUserFixture.username, adminUserFixture.password))
-      .then(newAccessToken => accessToken = newAccessToken.id)
-      .then(() => testUtils.createFixtureSequelize('Participant', testParticipants))
-  );
+  after(resetDatabase);
 
-  function expectParticipantInCampValues(expectedResult, response) {
-    const inCampValues = _.map(response.result, row => row.presence);
-    return expect(inCampValues).to.eql(expectedResult);
-  }
+  it('Should update whitelisted fields', async () => {
+    const res = await testUtils.postWithRoles('/api/participants/massAssign', ['registryUser'], {
+      ids: [ 1,2 ],
+      newValue: inCamp,
+      fieldName: 'presence',
+    });
 
-  function expectParticipantSubCampValues(expectedResult, response) {
-    const subCampValues = _.map(response.result, row => row.subCamp);
-    return expect(subCampValues).to.eql(expectedResult);
-  }
+    testUtils.expectStatus(res.status, 200);
+    expect(res.body).to.be.an('array').with.length(2);
+    expect(res.body[0]).to.have.property('firstName', 'Teemu');
 
-  //TODO: refactor this to query DB directly
-  function queryParticipants(accessToken) {
-    return request(app)
-    .get(`/api/participants?access_token=${accessToken}`)
-    .expect(200);
-  }
+    const participants = await models.Participant.findAll({ order: ['participantId'] });
+    expect(_.map(participants, 'presence')).to.eql([ inCamp, inCamp, tmpLeftCamp ]);
+  });
 
-  function postInstanceToDb(modelInPlural, changes, accessToken, expectStatus) {
-    return request(app)
-      .post(`/api/${modelInPlural}?access_token=${accessToken}`)
-      .send(changes);
-  }
+  it('Should not update fields that are not whitelisted', async () => {
+    const res = await testUtils.postWithRoles('/api/participants/massAssign', ['registryUser'], {
+      ids: [ 1,2 ],
+      newValue: 'alaleiri2',
+      fieldName: 'subCamp',
+    });
 
-  it('Should update whitelisted fields', () =>
-    postInstanceToDb('participants/massAssign', { ids: [ 1,2 ], newValue: inCamp, fieldName: 'presence' }, accessToken)
-      .expect(200)
-      .expect(result => {
-        expect(result.body).to.be.an('array').with.length(2);
-        expect(result.body[0]).to.have.property('firstName', 'Teemu');
-      })
-      .then( () => queryParticipants(accessToken)
-      .then( res => expectParticipantInCampValues([ inCamp, inCamp, tmpLeftCamp ], res.body) )
-   )
-  );
+    testUtils.expectStatus(res.status, 400);
 
-  it('Should not update fields that are not whitelisted', () =>
-    postInstanceToDb('participants/massAssign', { ids: [ 1,2 ], newValue: 'alaleiri2', fieldName: 'subCamp' }, accessToken)
-      .expect(400)
-      .then( () => queryParticipants(accessToken)
-      .then( res => expectParticipantSubCampValues([ 'Alaleiri', 'Alaleiri', 'Alaleiri' ], res.body) )
-    )
-  );
+    const participants = await models.Participant.findAll({ order: ['participantId'] });
+    expect(_.map(participants, 'subCamp')).to.eql([ 'Alaleiri', 'Alaleiri', 'Alaleiri' ]);
+  });
 
 });

--- a/test/functional/massedit-endpoint.test.js
+++ b/test/functional/massedit-endpoint.test.js
@@ -1,12 +1,10 @@
 import { models } from '../../src/server/models';
 import _ from 'lodash';
 import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import * as testUtils from '../utils/test-utils';
 import { resetDatabase } from '../../scripts/seed-database';
 
 const expect = chai.expect;
-chai.use(chaiAsPromised);
 
 describe('Participant mass edit endpoint test', () => {
   const inCamp = 3;
@@ -61,15 +59,18 @@ describe('Participant mass edit endpoint test', () => {
     },
   ];
 
+  let user;
+
   beforeEach(async() => {
     await resetDatabase();
     await testUtils.createFixtureSequelize('Participant', testParticipants);
+    user = await testUtils.createUserWithRoles(['registryUser']);
   });
 
   after(resetDatabase);
 
   it('Should update whitelisted fields', async () => {
-    const res = await testUtils.postWithRoles('/api/participants/massAssign', ['registryUser'], {
+    const res = await testUtils.postWithUser('/api/participants/massAssign', user, {
       ids: [ 1,2 ],
       newValue: inCamp,
       fieldName: 'presence',
@@ -84,7 +85,7 @@ describe('Participant mass edit endpoint test', () => {
   });
 
   it('Should not update fields that are not whitelisted', async () => {
-    const res = await testUtils.postWithRoles('/api/participants/massAssign', ['registryUser'], {
+    const res = await testUtils.postWithUser('/api/participants/massAssign', user, {
       ids: [ 1,2 ],
       newValue: 'alaleiri2',
       fieldName: 'subCamp',

--- a/test/functional/options.test.js
+++ b/test/functional/options.test.js
@@ -1,23 +1,8 @@
-import app from '../../src/server/server';
-import request from 'supertest';
 import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import * as testUtils from '../utils/test-utils';
 import { resetDatabase } from '../../scripts/seed-database';
 
 const expect = chai.expect;
-chai.use(chaiAsPromised);
-
-const testUser = {
-  'id': 1,
-  'username': 'testLooser',
-  'memberNumber': '00000002',
-  'email': 'jukka.pekka@example.com',
-  'password': 'salasa',
-  'firstName': 'Jukka',
-  'lastName': 'Pekka',
-  'phoneNumber': '0000000003',
-};
 
 const testOptions = [
   {
@@ -36,33 +21,24 @@ const testOptions = [
 
 describe('Options', () => {
 
-  let accessToken = null;
-
-  beforeEach( async () => {
+  beforeEach(async () => {
     await resetDatabase();
-    accessToken = await testUtils.createUserAndGetAccessToken(['registryUser'], testUser);
     await testUtils.createFixtureSequelize('Option', testOptions);
-    accessToken = accessToken.id;
   });
 
-  afterEach( async () => {
-    await testUtils.deleteFixturesIfExistSequelize('Option');
-    await testUtils.deleteFixturesIfExist('RegistryUser');
-  });
+  afterEach(resetDatabase);
 
-  it('GET request to options', async () =>
-    await request(app)
-    .get(`/api/options/?access_token=${accessToken}`)
-    .expect(200)
-    .expect(res => {
-      expect(res.body).to.be.an('array').with.length(3);
-      expect(res.body[0]).to.have.property('property','village');
-      expect(res.body[0]).to.have.property('value','Mallikylä');
-      expect(res.body[1]).to.have.property('property','village');
-      expect(res.body[1]).to.have.property('value','muu');
-      expect(res.body[2]).to.have.property('property','campGroup');
-      expect(res.body[2]).to.have.property('value','muu');
-    })
-  );
+  it('It returns filter options', async () => {
+    const res = await testUtils.getWithRoles('/api/options', ['registryUser']);
+    testUtils.expectStatus(res.status, 200);
+
+    expect(res.body).to.be.an('array').with.length(3);
+    expect(res.body[0]).to.have.property('property','village');
+    expect(res.body[0]).to.have.property('value','Mallikylä');
+    expect(res.body[1]).to.have.property('property','village');
+    expect(res.body[1]).to.have.property('value','muu');
+    expect(res.body[2]).to.have.property('property','campGroup');
+    expect(res.body[2]).to.have.property('value','muu');
+  });
 
 });

--- a/test/functional/options.test.js
+++ b/test/functional/options.test.js
@@ -20,16 +20,18 @@ const testOptions = [
 ];
 
 describe('Options', () => {
+  let user;
 
   beforeEach(async () => {
     await resetDatabase();
     await testUtils.createFixtureSequelize('Option', testOptions);
+    user = await testUtils.createUserWithRoles(['registryUser']);
   });
 
   afterEach(resetDatabase);
 
   it('It returns filter options', async () => {
-    const res = await testUtils.getWithRoles('/api/options', ['registryUser']);
+    const res = await testUtils.getWithUser('/api/options', user);
     testUtils.expectStatus(res.status, 200);
 
     expect(res.body).to.be.an('array').with.length(3);

--- a/test/functional/participant-date.test.js
+++ b/test/functional/participant-date.test.js
@@ -45,17 +45,19 @@ const testParticipantDates = [
 ];
 
 describe('particpantDates endpoint', () => {
+  let user;
 
   beforeEach(async () => {
     await resetDatabase();
     await testUtils.createFixtureSequelize('Participant', testParticipants);
     await testUtils.createFixtureSequelize('ParticipantDate', testParticipantDates);
+    user = await testUtils.createUserWithRoles(['registryUser']);
   });
 
   afterEach(resetDatabase);
 
   it('it returns unique dates when participants may be present', async () => {
-    const res = await testUtils.getWithRoles('/api/participantdates', ['registryUser']);
+    const res = await testUtils.getWithUser('/api/participantdates', user);
 
     testUtils.expectStatus(res.status, 200);
 

--- a/test/functional/participant-date.test.js
+++ b/test/functional/participant-date.test.js
@@ -1,12 +1,8 @@
-import app from '../../src/server/server';
-import request from 'supertest';
 import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import * as testUtils from '../utils/test-utils';
 import { resetDatabase } from '../../scripts/seed-database';
 
 const expect = chai.expect;
-chai.use(chaiAsPromised);
 
 const testParticipants = [
   {
@@ -48,47 +44,27 @@ const testParticipantDates = [
   { participantId: 2, date: new Date(2016,6,27) },
 ];
 
-const testUser = {
-  'id': 3,
-  'username': 'testLooser',
-  'memberNumber': '00000002',
-  'email': 'jukka.pekka@example.com',
-  'password': 'salasa',
-  'firstName': 'Jukka',
-  'lastName': 'Pekka',
-  'phoneNumber': '0000000003',
-};
-
-describe('particpantDates', () => {
-
-  let accessToken = null;
+describe('particpantDates endpoint', () => {
 
   beforeEach(async () => {
     await resetDatabase();
-    accessToken = await testUtils.createUserAndGetAccessToken(['registryUser'], testUser);
     await testUtils.createFixtureSequelize('Participant', testParticipants);
     await testUtils.createFixtureSequelize('ParticipantDate', testParticipantDates);
-    accessToken = accessToken.id;
   });
 
-  afterEach(async () => {
-    await testUtils.deleteFixturesIfExistSequelize('Participant');
-    await testUtils.deleteFixturesIfExistSequelize('ParticipantDate');
-    await testUtils.deleteFixturesIfExist('RegistryUser');
-  });
+  afterEach(resetDatabase);
 
-  it('GET request to participantdates', async () =>
-    await request(app)
-    .get(`/api/participantdates/?access_token=${accessToken}&filter=[fields][date]=true`)
-    .expect(200)
-    .expect(res => {
-      expect(res.body).to.be.an('array').with.length(5);
-      expect(res.body[0]).to.have.property('date','2016-07-20T00:00:00.000Z');
-      expect(res.body[1]).to.have.property('date','2016-07-21T00:00:00.000Z');
-      expect(res.body[2]).to.have.property('date','2016-07-22T00:00:00.000Z');
-      expect(res.body[3]).to.have.property('date','2016-07-23T00:00:00.000Z');
-      expect(res.body[4]).to.have.property('date','2016-07-27T00:00:00.000Z');
-    })
-  );
+  it('it returns unique dates when participants may be present', async () => {
+    const res = await testUtils.getWithRoles('/api/participantdates', ['registryUser']);
+
+    testUtils.expectStatus(res.status, 200);
+
+    expect(res.body).to.be.an('array').with.length(5);
+    expect(res.body[0]).to.have.property('date','2016-07-20T00:00:00.000Z');
+    expect(res.body[1]).to.have.property('date','2016-07-21T00:00:00.000Z');
+    expect(res.body[2]).to.have.property('date','2016-07-22T00:00:00.000Z');
+    expect(res.body[3]).to.have.property('date','2016-07-23T00:00:00.000Z');
+    expect(res.body[4]).to.have.property('date','2016-07-27T00:00:00.000Z');
+  });
 
 });

--- a/test/functional/participant-list.test.js
+++ b/test/functional/participant-list.test.js
@@ -152,4 +152,7 @@ describe('particpant list', () => {
     expect(response.count).to.equal(3);
   });
 
+  // TODO add test for no filters at all
+  // TODO add test for invalid filters
+
 });

--- a/test/functional/participant-list.test.js
+++ b/test/functional/participant-list.test.js
@@ -59,20 +59,24 @@ const testParticipantDates = [
 ];
 
 describe('particpant list', () => {
+  let user;
+
   before(resetDatabase);
 
   beforeEach(async () => {
     await testUtils.createFixtureSequelize('Participant', testParticipants);
     await testUtils.createFixtureSequelize('ParticipantDate', testParticipantDates);
+    user = await testUtils.createUserWithRoles(['registryUser']);
   });
 
   afterEach(async () => {
     await testUtils.deleteFixturesIfExistSequelize('Participant');
     await testUtils.deleteFixturesIfExistSequelize('ParticipantDate');
+    await testUtils.deleteFixturesIfExist('RegistryUser');
   });
 
   async function getParticipantsWithFilter(filter) {
-    const res = await testUtils.getWithRoles(`/api/participants/?filter=${filter}`, ['registryUser']);
+    const res = await testUtils.getWithUser(`/api/participants/?filter=${filter}`, user);
     testUtils.expectStatus(res.status, 200);
     return res.body;
   }

--- a/test/functional/participant-list.test.js
+++ b/test/functional/participant-list.test.js
@@ -79,7 +79,7 @@ describe('particpant list', () => {
 
   it('GET request to participants returs all participants', async () => {
     const response = await getParticipantsWithFilter(
-      '{"where":{},"skip":0,"limit":200,"include":["dates"],"count":true}'
+      '{"where":{},"skip":0,"limit":200}'
     );
     expect(response.result).to.be.an('array').with.length(3);
     expect(response.result[0]).to.have.property('firstName','Teemu');
@@ -87,7 +87,7 @@ describe('particpant list', () => {
 
   it('GET request to participants with one where filter', async () => {
     const response = await getParticipantsWithFilter(
-      '{"where":{"village":"Kattivaara"},"skip":0,"limit":200,"include":["dates"],"count":true}'
+      '{"where":{"village":"Kattivaara"},"skip":0,"limit":200}'
     );
     expect(response.result).to.be.an('array').with.length(1);
     expect(response.result[0]).to.have.property('firstName','Teemu');
@@ -95,7 +95,7 @@ describe('particpant list', () => {
 
   it('GET request to participants with several where filters', async () => {
     const response = await getParticipantsWithFilter(
-      '{"where":{"and":[{"ageGroup":"sudenpentu"},{"village":"Testikylä"}]},"skip":0,"limit":200,"include":["dates"],"count":true}'
+      '{"where":{"and":[{"ageGroup":"sudenpentu"},{"village":"Testikylä"}]},"skip":0,"limit":200}'
     );
     expect(response.result).to.be.an('array').with.length(1);
     expect(response.result[0]).to.have.property('firstName','Tero');
@@ -103,7 +103,7 @@ describe('particpant list', () => {
 
   it('GET request to participants returns dates', async () => {
     const response = await getParticipantsWithFilter(
-      '{"where":{},"skip":0,"limit":200,"include":["dates"],"count":true}'
+      '{"where":{},"skip":0,"limit":200}'
     );
     expect(response.result[0]).to.have.property('dates');
     expect(response.result[0].dates).to.be.an('array').with.length(3);
@@ -111,7 +111,7 @@ describe('particpant list', () => {
 
   it('GET request to participants skips correct amount of participants', async () => {
     const response = await getParticipantsWithFilter(
-      '{"where":{},"skip":2,"limit":1,"include":["dates"],"count":true}'
+      '{"where":{},"skip":2,"limit":1}'
     );
     expect(response.result).to.be.an('array').with.length(1);
     expect(response.result[0]).to.have.property('participantId',3);
@@ -120,7 +120,7 @@ describe('particpant list', () => {
 
   it('GET request to participants limits correct amount participants', async () => {
     const response = await getParticipantsWithFilter(
-      '{"where":{},"skip":0,"limit":2,"include":["dates"],"count":true}'
+      '{"where":{},"skip":0,"limit":2}'
     );
     expect(response.result).to.be.an('array').with.length(2);
     expect(response.result[0]).to.have.property('participantId',1);
@@ -129,7 +129,7 @@ describe('particpant list', () => {
 
   it('GET request to participants sorts participants correctly', async () => {
     const response = await getParticipantsWithFilter(
-      '{"where":{},"skip":0,"limit":200,"include":["dates"],"count":true,"order":"lastName DESC"}'
+      '{"where":{},"skip":0,"limit":200,"order":"lastName DESC"}'
     );
     expect(response.result).to.be.an('array').with.length(3);
     expect(response.result[0]).to.have.property('lastName','Testihenkilö');
@@ -139,7 +139,7 @@ describe('particpant list', () => {
 
   it('GET request to participants returns count', async () => {
     const response = await getParticipantsWithFilter(
-      '{"where":{},"skip":0,"limit":200,"include":["dates"],"count":true}'
+      '{"where":{},"skip":0,"limit":200}'
     );
     expect(response.count).to.equal(3);
   });
@@ -147,7 +147,7 @@ describe('particpant list', () => {
   //count should return the number of all maches regardless of the paging
   it('count is calculated correctly when skip and limit are present', async () => {
     const response = await getParticipantsWithFilter(
-      '{"where":{},"skip":1,"limit":2,"include":["dates"],"count":true}'
+      '{"where":{},"skip":1,"limit":2}'
     );
     expect(response.count).to.equal(3);
   });

--- a/test/functional/participant-list.test.js
+++ b/test/functional/participant-list.test.js
@@ -1,12 +1,8 @@
-import app from '../../src/server/server';
-import request from 'supertest';
 import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import * as testUtils from '../utils/test-utils';
 import { resetDatabase } from '../../scripts/seed-database';
 
 const expect = chai.expect;
-chai.use(chaiAsPromised);
 
 const testParticipants = [
   {
@@ -56,17 +52,6 @@ const testParticipants = [
   },
 ];
 
-const testUser = {
-  'id': 3,
-  'username': 'testLooser',
-  'memberNumber': '00000002',
-  'email': 'jukka.pekka@example.com',
-  'password': 'salasa',
-  'firstName': 'Jukka',
-  'lastName': 'Pekka',
-  'phoneNumber': '0000000003',
-};
-
 const testParticipantDates = [
   { participantId: 1, date: new Date(2016,6,20) },
   { participantId: 1, date: new Date(2016,6,21) },
@@ -74,114 +59,97 @@ const testParticipantDates = [
 ];
 
 describe('particpant list', () => {
-
-  let accessToken = null;
+  before(resetDatabase);
 
   beforeEach(async () => {
-    await resetDatabase();
     await testUtils.createFixtureSequelize('Participant', testParticipants);
     await testUtils.createFixtureSequelize('ParticipantDate', testParticipantDates);
-    accessToken = await testUtils.createUserAndGetAccessToken(['registryUser'], testUser);
-    accessToken = accessToken.id;
   });
 
   afterEach(async () => {
     await testUtils.deleteFixturesIfExistSequelize('Participant');
     await testUtils.deleteFixturesIfExistSequelize('ParticipantDate');
-    await testUtils.deleteFixturesIfExist('RegistryUser');
   });
 
-  it('GET request to participants returs all participants', async () =>
-    request(app)
-      .get(`/api/participants/?filter={"where":{},"skip":0,"limit":200,"include":["dates"],"count":true}&access_token=${accessToken}`)
-      .expect(200)
-      .expect(res => {
-        expect(res.body.result).to.be.an('array').with.length(3);
-        expect(res.body.result[0]).to.have.property('firstName','Teemu');
-      })
-  );
+  async function getParticipantsWithFilter(filter) {
+    const res = await testUtils.getWithRoles(`/api/participants/?filter=${filter}`, ['registryUser']);
+    testUtils.expectStatus(res.status, 200);
+    return res.body;
+  }
 
-  it('GET request to participants with one where filter', async () =>
-    request(app)
-      .get(`/api/participants/?filter={"where":{"village":"Kattivaara"},"skip":0,"limit":200,"include":["dates"],"count":true}&access_token=${accessToken}`)
-      .expect(200)
-      .expect(res => {
-        expect(res.body.result).to.be.an('array').with.length(1);
-        expect(res.body.result[0]).to.have.property('firstName','Teemu');
-      })
-  );
+  it('GET request to participants returs all participants', async () => {
+    const response = await getParticipantsWithFilter(
+      '{"where":{},"skip":0,"limit":200,"include":["dates"],"count":true}'
+    );
+    expect(response.result).to.be.an('array').with.length(3);
+    expect(response.result[0]).to.have.property('firstName','Teemu');
+  });
 
-  it('GET request to participants with several where filters', async () =>
-    request(app)
-      .get(`/api/participants/?filter={"where":{"and":[{"ageGroup":"sudenpentu"},{"village":"Testikylä"}]},"skip":0,"limit":200,"include":["dates"],"count":true}&access_token=${accessToken}`)
-      .expect(200)
-      .expect(res => {
-        expect(res.body.result).to.be.an('array').with.length(1);
-        expect(res.body.result[0]).to.have.property('firstName','Tero');
-      })
-  );
+  it('GET request to participants with one where filter', async () => {
+    const response = await getParticipantsWithFilter(
+      '{"where":{"village":"Kattivaara"},"skip":0,"limit":200,"include":["dates"],"count":true}'
+    );
+    expect(response.result).to.be.an('array').with.length(1);
+    expect(response.result[0]).to.have.property('firstName','Teemu');
+  });
 
-  it('GET request to participants returns dates', async () =>
-    request(app)
-      .get(`/api/participants/?filter={"where":{},"skip":0,"limit":200,"include":["dates"],"count":true}&access_token=${accessToken}`)
-      .expect(200)
-      .expect(res => {
-        expect(res.body.result[0]).to.have.property('dates');
-        expect(res.body.result[0].dates).to.be.an('array').with.length(3);
-      })
-  );
+  it('GET request to participants with several where filters', async () => {
+    const response = await getParticipantsWithFilter(
+      '{"where":{"and":[{"ageGroup":"sudenpentu"},{"village":"Testikylä"}]},"skip":0,"limit":200,"include":["dates"],"count":true}'
+    );
+    expect(response.result).to.be.an('array').with.length(1);
+    expect(response.result[0]).to.have.property('firstName','Tero');
+  });
 
-  it('GET request to participants skips correct amount of participants', async () =>
-    request(app)
-      .get(`/api/participants/?filter={"where":{},"skip":2,"limit":1,"include":["dates"],"count":true}&access_token=${accessToken}`)
-      .expect(200)
-      .expect(res => {
-        expect(res.body.result).to.be.an('array').with.length(1);
-        expect(res.body.result[0]).to.have.property('participantId',3);
-        expect(res.body.result[0]).to.have.property('firstName','Jussi');
-      })
-  );
+  it('GET request to participants returns dates', async () => {
+    const response = await getParticipantsWithFilter(
+      '{"where":{},"skip":0,"limit":200,"include":["dates"],"count":true}'
+    );
+    expect(response.result[0]).to.have.property('dates');
+    expect(response.result[0].dates).to.be.an('array').with.length(3);
+  });
 
-  it('GET request to participants limits correct amount participants', async () =>
-    request(app)
-      .get(`/api/participants/?filter={"where":{},"skip":0,"limit":2,"include":["dates"],"count":true}&access_token=${accessToken}`)
-      .expect(200)
-      .expect(res => {
-        expect(res.body.result).to.be.an('array').with.length(2);
-        expect(res.body.result[0]).to.have.property('participantId',1);
-        expect(res.body.result[0]).to.have.property('firstName','Teemu');
-      })
-  );
+  it('GET request to participants skips correct amount of participants', async () => {
+    const response = await getParticipantsWithFilter(
+      '{"where":{},"skip":2,"limit":1,"include":["dates"],"count":true}'
+    );
+    expect(response.result).to.be.an('array').with.length(1);
+    expect(response.result[0]).to.have.property('participantId',3);
+    expect(response.result[0]).to.have.property('firstName','Jussi');
+  });
 
-  it('GET request to participants sorts participants correctly', async () =>
-    request(app)
-      .get(`/api/participants/?filter={"where":{},"skip":0,"limit":200,"include":["dates"],"count":true,"order":"lastName DESC"}&access_token=${accessToken}`)
-      .expect(200)
-      .expect(res => {
-        expect(res.body.result).to.be.an('array').with.length(3);
-        expect(res.body.result[0]).to.have.property('lastName','Testihenkilö');
-        expect(res.body.result[1]).to.have.property('lastName','Jukola');
-        expect(res.body.result[2]).to.have.property('lastName','Esimerkki');
-      })
-  );
+  it('GET request to participants limits correct amount participants', async () => {
+    const response = await getParticipantsWithFilter(
+      '{"where":{},"skip":0,"limit":2,"include":["dates"],"count":true}'
+    );
+    expect(response.result).to.be.an('array').with.length(2);
+    expect(response.result[0]).to.have.property('participantId',1);
+    expect(response.result[0]).to.have.property('firstName','Teemu');
+  });
 
-  it('GET request to participants returns count', async () =>
-    request(app)
-      .get(`/api/participants/?filter={"where":{},"skip":0,"limit":200,"include":["dates"],"count":true}&access_token=${accessToken}`)
-      .expect(200)
-      .expect(res => {
-        expect(res.body.count).to.equal(3);
-      })
-  );
+  it('GET request to participants sorts participants correctly', async () => {
+    const response = await getParticipantsWithFilter(
+      '{"where":{},"skip":0,"limit":200,"include":["dates"],"count":true,"order":"lastName DESC"}'
+    );
+    expect(response.result).to.be.an('array').with.length(3);
+    expect(response.result[0]).to.have.property('lastName','Testihenkilö');
+    expect(response.result[1]).to.have.property('lastName','Jukola');
+    expect(response.result[2]).to.have.property('lastName','Esimerkki');
+  });
 
-  //count should retrun the number of all maches regardless of the paging
-  it('count is calculated correctly when skip and limit are present', async () =>
-    request(app)
-      .get(`/api/participants/?filter={"where":{},"skip":1,"limit":2,"include":["dates"],"count":true}&access_token=${accessToken}`)
-      .expect(200)
-      .expect(res => {
-        expect(res.body.count).to.equal(3);
-      })
-  );
+  it('GET request to participants returns count', async () => {
+    const response = await getParticipantsWithFilter(
+      '{"where":{},"skip":0,"limit":200,"include":["dates"],"count":true}'
+    );
+    expect(response.count).to.equal(3);
+  });
+
+  //count should return the number of all maches regardless of the paging
+  it('count is calculated correctly when skip and limit are present', async () => {
+    const response = await getParticipantsWithFilter(
+      '{"where":{},"skip":1,"limit":2,"include":["dates"],"count":true}'
+    );
+    expect(response.count).to.equal(3);
+  });
 
 });

--- a/test/functional/participant.test.js
+++ b/test/functional/participant.test.js
@@ -54,6 +54,7 @@ const testParticipantAllergies = [{
 }];
 
 describe('particpant', () => {
+  let user;
 
   before(resetDatabase);
 
@@ -64,6 +65,7 @@ describe('particpant', () => {
     await testUtils.createFixtureSequelize('Allergy', testAllergies);
     await testUtils.createFixtureSequelize('Selection', testParticipantsSelections);
     await testUtils.createFixtureSequelize('ParticipantAllergy', testParticipantAllergies);
+    user = await testUtils.createUserWithRoles(['registryUser']);
   });
 
   afterEach(async () => {
@@ -76,7 +78,7 @@ describe('particpant', () => {
   });
 
   it('request for single participant returns correct info', async () => {
-    const res = await testUtils.getWithRoles('/api/participants/1', ['registryUser']);
+    const res = await testUtils.getWithUser('/api/participants/1', user);
     testUtils.expectStatus(res.status, 200);
 
     expect(res.body).to.have.property('firstName','Teemu');
@@ -94,12 +96,12 @@ describe('particpant', () => {
   });
 
   it('request for unknown participant id returns 404', async () => {
-    const res = await testUtils.getWithRoles('/api/participants/404', ['registryUser']);
+    const res = await testUtils.getWithUser('/api/participants/404', user);
     testUtils.expectStatus(res.status, 404);
   });
 
   it('request for participant with string id returns 404', async () => {
-    const res = await testUtils.getWithRoles('/api/participants/hello', ['registryUser']);
+    const res = await testUtils.getWithUser('/api/participants/hello', user);
     testUtils.expectStatus(res.status, 404);
   });
 

--- a/test/functional/participant.test.js
+++ b/test/functional/participant.test.js
@@ -93,7 +93,7 @@ describe('particpant', () => {
 
   it('request for single participant returns correct info', async () =>
     request(app)
-      .get(`/api/participants/1?filter={"include":[{"presenceHistory":"author"},"allergies","dates","selections"]}&access_token=${accessToken}`)
+      .get(`/api/participants/1?access_token=${accessToken}`)
       .expect(200)
       .expect(res => {
         expect(res.body).to.have.property('firstName','Teemu');
@@ -113,13 +113,13 @@ describe('particpant', () => {
 
   it('request for unknown participant id returns 404', async () =>
     request(app)
-      .get(`/api/participants/404?filter={"include":[{"presenceHistory":"author"},"allergies","dates","selections"]}&access_token=${accessToken}`)
+      .get(`/api/participants/404?access_token=${accessToken}`)
       .expect(404)
   );
 
   it('request for participant with string id returns 404', async () =>
     request(app)
-      .get(`/api/participants/hello?filter={"include":[{"presenceHistory":"author"},"allergies","dates","selections"]}&access_token=${accessToken}`)
+      .get(`/api/participants/hello?access_token=${accessToken}`)
       .expect(404)
   );
 

--- a/test/functional/presence-history.test.js
+++ b/test/functional/presence-history.test.js
@@ -13,6 +13,8 @@ describe('Presence history', () => {
   const tmpLeftCamp = 2;
   const leftCamp = 1;
 
+  let user;
+
   const testParticipants = [
     {
       'participantId': 1,
@@ -63,7 +65,11 @@ describe('Presence history', () => {
 
   before(resetDatabase);
 
-  beforeEach(() => testUtils.createFixtureSequelize('Participant', testParticipants));
+  beforeEach(async () => {
+    await testUtils.createFixtureSequelize('Participant', testParticipants);
+    user = await testUtils.createUserWithRoles(['registryUser']);
+  });
+
   afterEach(() => testUtils.deleteFixturesIfExistSequelize('Participant'));
 
   function expectPresenceHistoryValues(expectedPresences, participantId, response) {
@@ -86,9 +92,9 @@ describe('Presence history', () => {
   }
 
   it('Should save history when updating one presence', async () => {
-    const res = await testUtils.postWithRoles(
+    const res = await testUtils.postWithUser(
       '/api/participants/massAssign',
-      ['registryUser'],
+      user,
       { ids: [ 1 ], newValue: inCamp, fieldName: 'presence' }
     );
     testUtils.expectStatus(res.status, 200);
@@ -96,7 +102,6 @@ describe('Presence history', () => {
   });
 
   it('Should save author correctly when updating presence twice', async () => {
-    const user = await testUtils.createUserWithRoles(['registryUser'], { username: 'presenceUser' });
     const res = await testUtils.postWithUser(
       '/api/participants/massAssign',
       user,
@@ -113,15 +118,15 @@ describe('Presence history', () => {
   });
 
   it('Should save history when updating presences twice', async () => {
-    const res = await testUtils.postWithRoles(
+    const res = await testUtils.postWithUser(
       '/api/participants/massAssign',
-      ['registryUser'],
+      user,
       { ids: [ 1 ], newValue: inCamp, fieldName: 'presence' }
     );
     testUtils.expectStatus(res.status, 200);
-    const res2 = await testUtils.postWithRoles(
+    const res2 = await testUtils.postWithUser(
       '/api/participants/massAssign',
-      ['registryUser'],
+      user,
       { ids: [ 1 ], newValue: leftCamp, fieldName: 'presence' }
     );
     testUtils.expectStatus(res2.status, 200);
@@ -129,15 +134,15 @@ describe('Presence history', () => {
   });
 
   it("Should save history when updating two participants' presences at once", async () => {
-    const res = await testUtils.postWithRoles(
+    const res = await testUtils.postWithUser(
       '/api/participants/massAssign',
-      ['registryUser'],
+      user,
       { ids: [ 2, 3 ], newValue: inCamp, fieldName: 'presence' }
     );
     testUtils.expectStatus(res.status, 200);
-    const res2 = await testUtils.postWithRoles(
+    const res2 = await testUtils.postWithUser(
       '/api/participants/massAssign',
-      ['registryUser'],
+      user,
       { ids: [ 2, 3 ], newValue: tmpLeftCamp, fieldName: 'presence' }
     );
     testUtils.expectStatus(res2.status, 200);
@@ -146,15 +151,15 @@ describe('Presence history', () => {
   });
 
   it('Should not save history when saving value doesn\'t change', async () => {
-    const res = await testUtils.postWithRoles(
+    const res = await testUtils.postWithUser(
       '/api/participants/massAssign',
-      ['registryUser'],
+      user,
       { ids: [ 2 ], newValue: inCamp, fieldName: 'presence' }
     );
     testUtils.expectStatus(res.status, 200);
-    const res2 = await testUtils.postWithRoles(
+    const res2 = await testUtils.postWithUser(
       '/api/participants/massAssign',
-      ['registryUser'],
+      user,
       { ids: [ 2 ], newValue: inCamp, fieldName: 'presence' }
     );
     testUtils.expectStatus(res2.status, 200);
@@ -162,9 +167,9 @@ describe('Presence history', () => {
   });
 
   it("Should not update wrong participants' presence", async () => {
-    const res = await testUtils.postWithRoles(
+    const res = await testUtils.postWithUser(
       '/api/participants/massAssign',
-      ['registryUser'],
+      user,
       { ids: [ 1 ], newValue: inCamp, fieldName: 'presence' }
     );
     testUtils.expectStatus(res.status, 200);
@@ -172,9 +177,9 @@ describe('Presence history', () => {
   });
 
   it('Should not save history when invalid presence data', async () => {
-    const res = await testUtils.postWithRoles(
+    const res = await testUtils.postWithUser(
       '/api/participants/massAssign',
-      ['registryUser'],
+      user,
       { ids: [ 1 ], newValue: 'some string value', fieldName: 'presence' }
     );
     testUtils.expectStatus(res.status, 400);

--- a/test/functional/presence-history.test.js
+++ b/test/functional/presence-history.test.js
@@ -1,6 +1,4 @@
-import app from '../../src/server/server';
 import _ from 'lodash';
-import request from 'supertest';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import * as testUtils from '../utils/test-utils';
@@ -11,8 +9,6 @@ const expect = chai.expect;
 chai.use(chaiAsPromised);
 
 describe('Presence history', () => {
-  let accessToken;
-
   const inCamp = 3;
   const tmpLeftCamp = 2;
   const leftCamp = 1;
@@ -65,23 +61,10 @@ describe('Presence history', () => {
     },
   ];
 
-  const adminUserFixture = {
-    'username': 'testAdmin',
-    'memberNumber': '7654321',
-    'email': 'testi@adm.in',
-    'password': 'salasana',
-    'phone': 'n/a',
-    'firstName': 'Testi',
-    'lastName': 'Admin',
-  };
+  before(resetDatabase);
 
-  beforeEach(() =>
-    resetDatabase()
-      .then(() => testUtils.createUserWithRoles(['registryUser', 'registryAdmin'], adminUserFixture))
-      .then(() => testUtils.loginUser(adminUserFixture.username, adminUserFixture.password))
-      .then(newAccessToken => accessToken = newAccessToken.id)
-      .then(() => testUtils.createFixtureSequelize('Participant', testParticipants))
-  );
+  beforeEach(() => testUtils.createFixtureSequelize('Participant', testParticipants));
+  afterEach(() => testUtils.deleteFixturesIfExistSequelize('Participant'));
 
   function expectPresenceHistoryValues(expectedPresences, participantId, response) {
     return models.PresenceHistory.findAll({
@@ -102,57 +85,100 @@ describe('Presence history', () => {
     );
   }
 
-  function postOverRest(modelInPlural, changes, accessToken) {
-    return request(app)
-      .post(`/api/${modelInPlural}?access_token=${accessToken}`)
-      .send(changes);
-  }
+  it('Should save history when updating one presence', async () => {
+    const res = await testUtils.postWithRoles(
+      '/api/participants/massAssign',
+      ['registryUser'],
+      { ids: [ 1 ], newValue: inCamp, fieldName: 'presence' }
+    );
+    testUtils.expectStatus(res.status, 200);
+    await expectPresenceHistoryValues([ inCamp ], 1 );
+  });
 
-  it('Should save history when updating one presence', () =>
-    postOverRest('participants/massAssign', { ids: [ 1 ], newValue: inCamp, fieldName: 'presence' }, accessToken)
-      .expect(200)
-      .then( () => expectPresenceHistoryValues([ inCamp ], 1 ) )
-  );
+  it('Should save author correctly when updating presence twice', async () => {
+    const user = await testUtils.createUserWithRoles(['registryUser'], { username: 'presenceUser' });
+    const res = await testUtils.postWithUser(
+      '/api/participants/massAssign',
+      user,
+      { ids: [ 1 ], newValue: inCamp, fieldName: 'presence' }
+    );
+    testUtils.expectStatus(res.status, 200);
+    const res2 = await testUtils.postWithUser(
+      '/api/participants/massAssign',
+      user,
+      { ids: [ 1 ], newValue: tmpLeftCamp, fieldName: 'presence' }
+    );
+    testUtils.expectStatus(res2.status, 200);
+    await expectPresenceAuthorValue([ user.id, user.id ], 1 );
+  });
 
-  it('Should save author correctly when updating presence', () =>
-    postOverRest('participants/massAssign', { ids: [ 1 ], newValue: inCamp, fieldName: 'presence' }, accessToken)
-      .expect(200)
-      .then( () => postOverRest('participants/massAssign', { ids: [ 1 ], newValue: tmpLeftCamp, fieldName: 'presence' }, accessToken).expect(200) )
-      .then( () => expectPresenceAuthorValue([ 1, 1 ], 1 ) )
-  );
+  it('Should save history when updating presences twice', async () => {
+    const res = await testUtils.postWithRoles(
+      '/api/participants/massAssign',
+      ['registryUser'],
+      { ids: [ 1 ], newValue: inCamp, fieldName: 'presence' }
+    );
+    testUtils.expectStatus(res.status, 200);
+    const res2 = await testUtils.postWithRoles(
+      '/api/participants/massAssign',
+      ['registryUser'],
+      { ids: [ 1 ], newValue: leftCamp, fieldName: 'presence' }
+    );
+    testUtils.expectStatus(res2.status, 200);
+    await expectPresenceHistoryValues([ inCamp, leftCamp ], 1 );
+  });
 
-  it('Should save history when updating two presences', () =>
-    postOverRest('participants/massAssign', { ids: [ 1 ], newValue: inCamp, fieldName: 'presence' }, accessToken)
-      .expect(200)
-      .then( () => postOverRest('participants/massAssign', { ids: [ 1 ], newValue: leftCamp, fieldName: 'presence' }, accessToken).expect(200) )
-      .then( () => expectPresenceHistoryValues([ inCamp, leftCamp ], 1 ) )
-  );
+  it("Should save history when updating two participants' presences at once", async () => {
+    const res = await testUtils.postWithRoles(
+      '/api/participants/massAssign',
+      ['registryUser'],
+      { ids: [ 2, 3 ], newValue: inCamp, fieldName: 'presence' }
+    );
+    testUtils.expectStatus(res.status, 200);
+    const res2 = await testUtils.postWithRoles(
+      '/api/participants/massAssign',
+      ['registryUser'],
+      { ids: [ 2, 3 ], newValue: tmpLeftCamp, fieldName: 'presence' }
+    );
+    testUtils.expectStatus(res2.status, 200);
+    await expectPresenceHistoryValues([ inCamp, tmpLeftCamp ], 2 );
+    await expectPresenceHistoryValues([ inCamp, tmpLeftCamp ], 3 );
+  });
 
-  it('Should save history when updating two participants presences at once', () =>
-    postOverRest('participants/massAssign', { ids: [ 2, 3 ], newValue: inCamp, fieldName: 'presence' }, accessToken)
-      .expect(200)
-      .then( () => postOverRest('participants/massAssign', { ids: [ 2, 3 ], newValue: tmpLeftCamp, fieldName: 'presence' }, accessToken).expect(200) )
-      .then( () => expectPresenceHistoryValues([ inCamp, tmpLeftCamp ], 2 ) )
-      .then( () => expectPresenceHistoryValues([ inCamp, tmpLeftCamp ], 3 ) )
-  );
+  it('Should not save history when saving value doesn\'t change', async () => {
+    const res = await testUtils.postWithRoles(
+      '/api/participants/massAssign',
+      ['registryUser'],
+      { ids: [ 2 ], newValue: inCamp, fieldName: 'presence' }
+    );
+    testUtils.expectStatus(res.status, 200);
+    const res2 = await testUtils.postWithRoles(
+      '/api/participants/massAssign',
+      ['registryUser'],
+      { ids: [ 2 ], newValue: inCamp, fieldName: 'presence' }
+    );
+    testUtils.expectStatus(res2.status, 200);
+    await expectPresenceHistoryValues([ inCamp ], 2 );
+  });
 
-  it('Should not save history when saving value doesn\'t change', () =>
-    postOverRest('participants/massAssign', { ids: [ 2 ], newValue: inCamp, fieldName: 'presence' }, accessToken)
-      .expect(200)
-    .then( () => postOverRest('participants/massAssign', { ids: [ 2 ], newValue: inCamp, fieldName: 'presence' }, accessToken).expect(200) )
-      .then( () => expectPresenceHistoryValues([ inCamp ], 2 ) )
-  );
+  it("Should not update wrong participants' presence", async () => {
+    const res = await testUtils.postWithRoles(
+      '/api/participants/massAssign',
+      ['registryUser'],
+      { ids: [ 1 ], newValue: inCamp, fieldName: 'presence' }
+    );
+    testUtils.expectStatus(res.status, 200);
+    await expectPresenceHistoryValues([ ], 2 );
+  });
 
-  it('Should not update wrong participants presence', () =>
-    postOverRest('participants/massAssign', { ids: [ 1 ], newValue: inCamp, fieldName: 'presence' }, accessToken)
-      .expect(200)
-      .then( () => expectPresenceHistoryValues([ ], 2 ) )
-  );
-
-  it('Should not save history when unvalid presence data', () =>
-    postOverRest('participants/massAssign', { ids: [ 1 ], newValue: 'some string value', fieldName: 'presence' }, accessToken)
-      .expect(400)
-      .then( () => expectPresenceHistoryValues([ ], 1 ) )
-  );
+  it('Should not save history when invalid presence data', async () => {
+    const res = await testUtils.postWithRoles(
+      '/api/participants/massAssign',
+      ['registryUser'],
+      { ids: [ 1 ], newValue: 'some string value', fieldName: 'presence' }
+    );
+    testUtils.expectStatus(res.status, 400);
+    await expectPresenceHistoryValues([ ], 1 );
+  });
 
 });

--- a/test/functional/presence-history.test.js
+++ b/test/functional/presence-history.test.js
@@ -1,12 +1,10 @@
 import _ from 'lodash';
 import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import * as testUtils from '../utils/test-utils';
 import { resetDatabase } from '../../scripts/seed-database';
 import { models } from '../../src/server/models';
 
 const expect = chai.expect;
-chai.use(chaiAsPromised);
 
 describe('Presence history', () => {
   const inCamp = 3;

--- a/test/functional/registry-user.test.js
+++ b/test/functional/registry-user.test.js
@@ -1,11 +1,8 @@
 import app from '../../src/server/server';
 import request from 'supertest';
 import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import * as testUtils from '../utils/test-utils';
 import { resetDatabase } from '../../scripts/seed-database';
-
-chai.use(chaiAsPromised);
 
 const expect = chai.expect;
 
@@ -21,7 +18,7 @@ const blockedUser = {
   'status': 'blocked',
 };
 
-const unBLockedUser = {
+const unblockedUser = {
   'id': 2,
   'username': 'testJumala',
   'memberNumber': '00000001',
@@ -44,74 +41,74 @@ const testUser = {
 };
 
 describe('RegistryUser', () => {
-  let accessTokenAdmin;
-  let accessTokenUser;
+  let user;
 
-  beforeEach( async () => {
-    await resetDatabase();
+  before(resetDatabase);
+
+  beforeEach(async () => {
     await testUtils.createUserWithRoles(['registryUser'], blockedUser);
-    accessTokenUser = await testUtils.createUserAndGetAccessToken(['registryUser'], unBLockedUser);
-    accessTokenUser = accessTokenUser.id;
-    accessTokenAdmin = await testUtils.createUserAndGetAccessToken(['registryAdmin'], testUser);
-    accessTokenAdmin = accessTokenAdmin.id;
+    await testUtils.createUserWithRoles(['registryUser'], unblockedUser);
+    user = await testUtils.createUserWithRoles(['registryAdmin'], testUser);
   });
 
   afterEach(() => testUtils.deleteFixturesIfExist('RegistryUser'));
 
-  it('GET request to registryUsers returns an array', async () => {
-    await request(app).get(`/api/registryusers?access_token=${accessTokenAdmin}`)
-      .expect(200)
-      .expect(res => {
-        expect(res.body).to.be.an('array').with.length(3);
-        expect(res.body[0]).to.have.property('id').to.be.above(0);
-      });
+  it('GET request to registryUsers returns an array of all users', async () => {
+    const res = await testUtils.getWithUser('/api/registryusers', user);
+    testUtils.expectStatus(res.status, 200);
+    expect(res.body).to.be.an('array').with.length(3);
+    expect(res.body[0]).to.have.property('id').to.be.above(0);
   });
 
   it('GET request to registryUsers returns one user when id is users own id', async () => {
-    await request(app).get(`/api/registryusers/3/?access_token=${accessTokenAdmin}`)
-      .expect(200)
-      .expect(res => {
-        expect(res.body).to.have.property('id', 3);
-        expect(res.body).to.have.property('username','testLooser');
-        expect(res.body).to.have.property('memberNumber','00000002');
-        expect(res.body).to.have.property('email','jukka.pekka@example.com');
-        expect(res.body).to.not.have.property('password');
-        expect(res.body).to.have.property('firstName','Jukka');
-        expect(res.body).to.have.property('lastName','Pekka');
-        expect(res.body).to.have.property('phoneNumber','0000000003');
-      });
+    const res = await testUtils.getWithUser('/api/registryusers/3', user);
+    testUtils.expectStatus(res.status, 200);
+
+    expect(res.body).to.have.property('id', 3);
+    expect(res.body).to.have.property('username','testLooser');
+    expect(res.body).to.have.property('memberNumber','00000002');
+    expect(res.body).to.have.property('email','jukka.pekka@example.com');
+    expect(res.body).to.not.have.property('password');
+    expect(res.body).to.have.property('firstName','Jukka');
+    expect(res.body).to.have.property('lastName','Pekka');
+    expect(res.body).to.have.property('phoneNumber','0000000003');
   });
 
-  it('GET request to registryUsers returns 401 when id is not users own id', async () =>
-    await request(app).get(`/api/registryusers/1/?access_token=${accessTokenUser}`)
-      .expect(401)
-  );
+  it('GET request to registryUsers returns 401 when id is not users own id', async () => {
+    const res = await testUtils.getWithUser('/api/registryusers/1', user);
+    testUtils.expectStatus(res.status, 401);
+  });
 
   it('if user is blocked status changes in database', async () => {
-    await request(app).post(`/api/registryusers/2/block?access_token=${accessTokenAdmin}`)
-      .expect(204);
-    const user = await app.models.RegistryUser.findById(2);
-    expect(app.models.RegistryUser.isBlocked(user)).is.true;
+    const res = await testUtils.postWithUser('/api/registryusers/2/block', user, null);
+    testUtils.expectStatus(res.status, 204);
+
+    const affectedUser = await app.models.RegistryUser.findById(2);
+    expect(app.models.RegistryUser.isBlocked(affectedUser)).is.true;
   });
 
   it('if user is unblocked status changes in database', async () => {
-    await request(app).post(`/api/registryusers/1/unblock?access_token=${accessTokenAdmin}`)
-      .expect(204);
-    const user = await app.models.RegistryUser.findById(1);
-    expect(app.models.RegistryUser.isBlocked(user)).is.false;
+    const res = await testUtils.postWithUser('/api/registryusers/1/unblock', user, null);
+    testUtils.expectStatus(res.status, 204);
+
+    const affectedUser = await app.models.RegistryUser.findById(1);
+    expect(app.models.RegistryUser.isBlocked(affectedUser)).is.false;
   });
 
   it('logout should destroy accestoken in query param', async () => {
-    await request(app).post(`/api/registryusers/logout?access_token=${accessTokenAdmin}`)
+    const token = await user.createAccessToken(1000);
+    await request(app)
+      .post(`/api/registryusers/logout?access_token=${token.id}`)
       .expect(204);
-    expect(await app.models.AccessToken.findById(accessTokenAdmin)).to.be.null;
+    expect(await app.models.AccessToken.findById(token.id)).to.be.null;
   });
 
   it('logout should destroy accestoken in Authorization header', async () => {
+    const token = await user.createAccessToken(1000);
     await request(app).post('/api/registryusers/logout')
-      .set('Authorization', accessTokenAdmin)
+      .set('Authorization', token.id)
       .expect(204);
-    expect(await app.models.AccessToken.findById(accessTokenAdmin)).to.be.null;
+    expect(await app.models.AccessToken.findById(token.id)).to.be.null;
   });
 
 });

--- a/test/functional/search-filter.test.js
+++ b/test/functional/search-filter.test.js
@@ -1,5 +1,3 @@
-import app from '../../src/server/server';
-import request from 'supertest';
 import chai from 'chai';
 import * as testUtils from '../utils/test-utils';
 import { resetDatabase } from '../../scripts/seed-database';
@@ -8,80 +6,72 @@ import { models } from '../../src/server/models';
 const expect = chai.expect;
 
 describe('SearchFilter', () => {
-  let accessToken;
+  const searchFilterFixture = {
+    name: 'asd',
+    filter: '?filter=%7B"textSearch"%3A"durpdurp"%7D',
+  };
 
-  const searchFilterFixture = [
-    {
-      name: 'asd',
-      filter: '?filter=%7B"textSearch"%3A"durpdurp"%7D',
-    }];
+  before(resetDatabase);
 
-  beforeEach( async () => {
-    await resetDatabase();
-    accessToken = await testUtils.createUserAndGetAccessToken(['registryUser']);
-    accessToken = accessToken.id;
-  });
   afterEach(() => testUtils.deleteFixturesIfExistSequelize('SearchFilter'));
 
   it('GET SearchFilter returns a filter when not empty', async () => {
     await testUtils.createFixtureSequelize('SearchFilter', searchFilterFixture);
-    return request(app).get(`/api/searchfilters?access_token=${accessToken}`)
-    .expect(200)
-    .expect(res => {
-      expect(res.body).to.be.an('array').with.length(1);
-      expect(res.body[0]).to.have.property('id').to.be.above(0);
-      expect(res.body[0]).to.have.property('name', 'asd');
-      expect(res.body[0]).to.have.property('filter', '?filter=%7B"textSearch"%3A"durpdurp"%7D');
-    });
+    const res = await testUtils.getWithRoles('/api/searchfilters', ['registryUser']);
+    testUtils.expectStatus(res.status, 200);
+
+    expect(res.body).to.be.an('array').with.length(1);
+    expect(res.body[0]).to.have.property('id').to.be.above(0);
+    expect(res.body[0]).to.have.property('name', 'asd');
+    expect(res.body[0]).to.have.property('filter', '?filter=%7B"textSearch"%3A"durpdurp"%7D');
   });
 
-  it('GET SearchFilter returns empty array when there are no search filters', async () =>
-    request(app).get(`/api/searchfilters?access_token=${accessToken}`)
-    .expect(200)
-    .expect(res => {
-      expect(res.body).to.be.an('array').with.length(0);
-    })
-  );
+  it('GET SearchFilter returns empty array when there are no search filters', async () => {
+    const res = await testUtils.getWithRoles('/api/searchfilters', ['registryUser']);
+    testUtils.expectStatus(res.status, 200);
+    expect(res.body).to.be.an('array').with.length(0);
+  });
 
   it('POST request to SearchFilter returns the filter and saves it to database', async () => {
-    await request(app).post('/api/searchfilters')
-    .set('Authorization', accessToken)
-    .send({
-      filter:'?filter=%7B%22textSearch%22%3A%22asd%22%7D',
-      name:'ok',
-    })
-    .expect(200)
-    .expect(res => {
-      expect(res.body).to.have.property('id').to.be.above(0);
-      expect(res.body).to.have.property('name', 'ok');
-      expect(res.body).to.have.property('filter', '?filter=%7B%22textSearch%22%3A%22asd%22%7D');
-    });
+    const res = await testUtils.postWithRoles(
+      '/api/searchfilters',
+      ['registryUser'],
+      {
+        filter:'?filter=%7B%22textSearch%22%3A%22asd%22%7D',
+        name:'ok',
+      }
+    );
+    testUtils.expectStatus(res.status, 200);
+
+    expect(res.body).to.have.property('id').to.be.above(0);
+    expect(res.body).to.have.property('name', 'ok');
+    expect(res.body).to.have.property('filter', '?filter=%7B%22textSearch%22%3A%22asd%22%7D');
+
     const filters = await models.SearchFilter.findAll();
     expect(filters).to.be.an('array').with.length(1);
   });
 
   it('DELETE request destroys the filter we tried to destroy from the database', async () => {
-    await testUtils.createFixtureSequelize('SearchFilter', searchFilterFixture);
-    await request(app).delete('/api/searchfilters/1')
-      .set('Authorization', accessToken)
-      .expect(200);
+    const filter = await models.SearchFilter.create(searchFilterFixture);
+    const res = await testUtils.deleteWithRoles(`/api/searchfilters/${filter.id}`, ['registryUser']);
+    testUtils.expectStatus(res.status, 200);
+
     const filters = await models.SearchFilter.findAll();
     expect(filters).to.be.an('array').with.length(0);
   });
 
   it('DELETE request returns 404 if filter is not found', async () => {
-    await testUtils.createFixtureSequelize('SearchFilter', searchFilterFixture);
-    await request(app).delete('/api/searchfilters/3')
-      .set('Authorization', accessToken)
-      .expect(404);
+    const filter = await testUtils.createFixtureSequelize('SearchFilter', searchFilterFixture);
+    const res = await testUtils.deleteWithRoles(`/api/searchfilters/${filter.id+1}`, ['registryUser']);
+    testUtils.expectStatus(res.status, 404);
+
     const filters = await models.SearchFilter.findAll();
     expect(filters).to.be.an('array').with.length(1);
   });
 
-  it('DELETE request returns 404 for non-integer ids', () =>
-    request(app).delete('/api/searchfilters/hello')
-      .set('Authorization', accessToken)
-      .expect(404)
-  );
+  it('DELETE request returns 404 for non-integer ids', async () => {
+    const res = await testUtils.deleteWithRoles('/api/searchfilters/hello', ['registryUser']);
+    testUtils.expectStatus(res.status, 404);
+  });
 
 });

--- a/test/functional/search-filter.test.js
+++ b/test/functional/search-filter.test.js
@@ -11,13 +11,20 @@ describe('SearchFilter', () => {
     filter: '?filter=%7B"textSearch"%3A"durpdurp"%7D',
   };
 
+  let user;
+
   before(resetDatabase);
 
-  afterEach(() => testUtils.deleteFixturesIfExistSequelize('SearchFilter'));
+  beforeEach(async () => user = await testUtils.createUserWithRoles(['registryUser']));
+
+  afterEach(async () => {
+    await testUtils.deleteFixturesIfExistSequelize('SearchFilter');
+    await testUtils.deleteFixturesIfExist('RegistryUser');
+  });
 
   it('GET SearchFilter returns a filter when not empty', async () => {
     await testUtils.createFixtureSequelize('SearchFilter', searchFilterFixture);
-    const res = await testUtils.getWithRoles('/api/searchfilters', ['registryUser']);
+    const res = await testUtils.getWithUser('/api/searchfilters', user);
     testUtils.expectStatus(res.status, 200);
 
     expect(res.body).to.be.an('array').with.length(1);
@@ -27,15 +34,15 @@ describe('SearchFilter', () => {
   });
 
   it('GET SearchFilter returns empty array when there are no search filters', async () => {
-    const res = await testUtils.getWithRoles('/api/searchfilters', ['registryUser']);
+    const res = await testUtils.getWithUser('/api/searchfilters', user);
     testUtils.expectStatus(res.status, 200);
     expect(res.body).to.be.an('array').with.length(0);
   });
 
   it('POST request to SearchFilter returns the filter and saves it to database', async () => {
-    const res = await testUtils.postWithRoles(
+    const res = await testUtils.postWithUser(
       '/api/searchfilters',
-      ['registryUser'],
+      user,
       {
         filter:'?filter=%7B%22textSearch%22%3A%22asd%22%7D',
         name:'ok',
@@ -53,7 +60,7 @@ describe('SearchFilter', () => {
 
   it('DELETE request destroys the filter we tried to destroy from the database', async () => {
     const filter = await models.SearchFilter.create(searchFilterFixture);
-    const res = await testUtils.deleteWithRoles(`/api/searchfilters/${filter.id}`, ['registryUser']);
+    const res = await testUtils.deleteWithUser(`/api/searchfilters/${filter.id}`, user);
     testUtils.expectStatus(res.status, 200);
 
     const filters = await models.SearchFilter.findAll();
@@ -62,7 +69,7 @@ describe('SearchFilter', () => {
 
   it('DELETE request returns 404 if filter is not found', async () => {
     const filter = await testUtils.createFixtureSequelize('SearchFilter', searchFilterFixture);
-    const res = await testUtils.deleteWithRoles(`/api/searchfilters/${filter.id+1}`, ['registryUser']);
+    const res = await testUtils.deleteWithUser(`/api/searchfilters/${filter.id+1}`, user);
     testUtils.expectStatus(res.status, 404);
 
     const filters = await models.SearchFilter.findAll();
@@ -70,7 +77,7 @@ describe('SearchFilter', () => {
   });
 
   it('DELETE request returns 404 for non-integer ids', async () => {
-    const res = await testUtils.deleteWithRoles('/api/searchfilters/hello', ['registryUser']);
+    const res = await testUtils.deleteWithUser('/api/searchfilters/hello', user);
     testUtils.expectStatus(res.status, 404);
   });
 

--- a/test/functional/text-search.test.js
+++ b/test/functional/text-search.test.js
@@ -130,7 +130,7 @@ describe('Text search', () => {
   );
 
   it('Query with part of name', () =>
-    queryParticipants({ 'and':[{ 'ageGroup':'sudenpentu' },{ 'textSearch':'Te' }] })
+    queryParticipants({ 'and':[{ 'localGroup':'Testilippukunta' },{ 'textSearch':'Te' }] })
     .then(res => {
       expectParticipants([ 'Tero', 'Teemu' ], res.body);
     })

--- a/test/functional/text-search.test.js
+++ b/test/functional/text-search.test.js
@@ -1,5 +1,3 @@
-import app from '../../src/server/server';
-import request from 'supertest';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import * as testUtils from '../utils/test-utils';
@@ -63,144 +61,132 @@ describe('Text search', () => {
     },
   ];
 
-  const adminUserFixture = {
-    'username': 'testAdmin',
-    'memberNumber': '7654321',
-    'email': 'testi@adm.in',
-    'password': 'salasana',
-    'phone': 'n/a',
-    'firstName': 'Testi',
-    'lastName': 'Admin',
-  };
+  before(resetDatabase);
 
-  let accessToken = null;
-
-  beforeEach(() =>
-    resetDatabase()
-      .then(() => testUtils.createUserWithRoles(['registryUser'], adminUserFixture))
-      .then(() => testUtils.createFixtureSequelize('Participant', testParticipants))
-      .then(() => testUtils.loginUser(adminUserFixture.username, adminUserFixture.password))
-      .then(newAccessToken => accessToken = newAccessToken.id)
-  );
+  beforeEach(() => testUtils.createFixtureSequelize('Participant', testParticipants));
+  afterEach(() => testUtils.deleteFixturesIfExistSequelize('Participant'));
 
   function expectParticipants(expectedResult, response) {
     const firstNames = _.map(response.result, 'firstName');
     return expect(firstNames).to.have.members(expectedResult);
   }
 
-  function queryParticipants(filter, accessToken) {
-    return request(app)
-      .get(`/api/participants/?access_token=${accessToken}&filter={"where":${encodeURIComponent(JSON.stringify(filter))},"skip":0,"limit":20}`)
-      .expect(200);
+  async function queryParticipants(filter) {
+    const res = await testUtils.getWithRoles(
+      `/api/participants/?filter={"where":${encodeURIComponent(JSON.stringify(filter))},"skip":0,"limit":20}`,
+      ['registryUser']
+    );
+    testUtils.expectStatus(res.status, 200);
+    return res;
   }
 
   it('Query without filters', () =>
-    queryParticipants({}, accessToken)
+    queryParticipants({})
     .then(res => {
       expectParticipants([ 'Tero', 'Teemu', 'Jussi' ], res.body);
     })
   );
 
   it('Query with ageGroup filter', () =>
-    queryParticipants({ 'ageGroup':'sudenpentu' }, accessToken)
+    queryParticipants({ 'ageGroup':'sudenpentu' })
     .then(res => {
       expectParticipants([ 'Tero', 'Teemu' ], res.body);
     })
   );
 
   it('Query with search by last name', () =>
-    queryParticipants({ 'textSearch':'Esimerkki' }, accessToken)
+    queryParticipants({ 'textSearch':'Esimerkki' })
     .then(res => {
       expectParticipants([ 'Tero' ], res.body);
     })
   );
 
   it('Query with search by first name small caps', () =>
-    queryParticipants({ 'textSearch':'tero' }, accessToken)
+    queryParticipants({ 'textSearch':'tero' })
     .then(res => {
       expectParticipants([ 'Tero' ], res.body);
     })
   );
 
   it('Query with multiple filters', () =>
-    queryParticipants({ 'and':[{ 'ageGroup':'sudenpentu' },{ 'subCamp':'Alaleiri' },{ 'textSearch':'Teemu' }] }, accessToken)
+    queryParticipants({ 'and':[{ 'ageGroup':'sudenpentu' },{ 'subCamp':'Alaleiri' },{ 'textSearch':'Teemu' }] })
     .then(res => {
       expectParticipants([ 'Teemu' ], res.body);
     })
   );
 
   it('Query with multiple filters without results', () =>
-    queryParticipants({ 'and':[{ 'ageGroup':'seikkailija' },{ 'textSearch':'Teemu' }] }, accessToken)
+    queryParticipants({ 'and':[{ 'ageGroup':'seikkailija' },{ 'textSearch':'Teemu' }] })
     .then(res => {
       expectParticipants([ ], res.body);
     })
   );
 
   it('Query with multiple filters without text search', () =>
-    queryParticipants({ 'and':[{ 'ageGroup':'seikkailija' },{ 'subCamp':'Alaleiri' }] }, accessToken)
+    queryParticipants({ 'and':[{ 'ageGroup':'seikkailija' },{ 'subCamp':'Alaleiri' }] })
     .then(res => {
       expectParticipants([ 'Jussi' ], res.body);
     })
   );
 
   it('Query with part of name', () =>
-    queryParticipants({ 'and':[{ 'ageGroup':'sudenpentu' },{ 'textSearch':'Te' }] }, accessToken)
+    queryParticipants({ 'and':[{ 'ageGroup':'sudenpentu' },{ 'textSearch':'Te' }] })
     .then(res => {
       expectParticipants([ 'Tero', 'Teemu' ], res.body);
     })
   );
 
   it('Query with member number', () =>
-    queryParticipants({ 'textSearch':'859' }, accessToken)
+    queryParticipants({ 'textSearch':'859' })
     .then(res => {
       expectParticipants([ 'Jussi' ], res.body);
     })
   );
 
   it('Query with first and last name', () =>
-    queryParticipants({ 'textSearch':'Jukola Jussi' }, accessToken)
+    queryParticipants({ 'textSearch':'Jukola Jussi' })
     .then(res => {
       expectParticipants([ 'Jussi' ], res.body);
     })
   );
 
   it('Query with staff position', () =>
-    queryParticipants({ 'textSearch':'Jumppaohjaaja' }, accessToken)
+    queryParticipants({ 'textSearch':'Jumppaohjaaja' })
     .then(res => {
       expectParticipants([ 'Tero' ], res.body);
     })
   );
 
   it('Query with staff position in generator', () =>
-    queryParticipants({ 'textSearch':'Tiskari' }, accessToken)
+    queryParticipants({ 'textSearch':'Tiskari' })
     .then(res => {
       expectParticipants([ 'Teemu', 'Jussi' ], res.body);
     })
   );
 
   it('Query with partial staff position', () =>
-    queryParticipants({ 'textSearch':'tisk' }, accessToken)
+    queryParticipants({ 'textSearch':'tisk' })
     .then(res => {
       expectParticipants([ 'Teemu', 'Jussi' ], res.body);
     })
   );
 
   it('Query with hashtag', () =>
-    queryParticipants({ 'textSearch':'#Tiskari' }, accessToken)
+    queryParticipants({ 'textSearch':'#Tiskari' })
     .then(res => {
       expectParticipants([ 'Jussi' ], res.body);
     })
   );
 
   it('Query with camp office notes', () =>
-    queryParticipants({ 'textSearch':'Leiritoimisto' }, accessToken)
+    queryParticipants({ 'textSearch':'Leiritoimisto' })
     .then(res => {
       expectParticipants([ 'Tero' ], res.body);
     })
   );
 
   it('Query with editable info', () =>
-    queryParticipants({ 'textSearch':'Muokattava' }, accessToken)
+    queryParticipants({ 'textSearch':'Muokattava' })
     .then(res => {
       expectParticipants([ 'Teemu' ], res.body);
     })

--- a/test/functional/text-search.test.js
+++ b/test/functional/text-search.test.js
@@ -61,10 +61,19 @@ describe('Text search', () => {
     },
   ];
 
+  let user;
+
   before(resetDatabase);
 
-  beforeEach(() => testUtils.createFixtureSequelize('Participant', testParticipants));
-  afterEach(() => testUtils.deleteFixturesIfExistSequelize('Participant'));
+  beforeEach(async () => {
+    await testUtils.createFixtureSequelize('Participant', testParticipants);
+    user = await testUtils.createUserWithRoles(['registryUser']);
+  });
+
+  afterEach(async () => {
+    await testUtils.deleteFixturesIfExistSequelize('Participant');
+    await testUtils.deleteFixturesIfExist('RegistryUser');
+  });
 
   function expectParticipants(expectedResult, response) {
     const firstNames = _.map(response.result, 'firstName');
@@ -72,9 +81,9 @@ describe('Text search', () => {
   }
 
   async function queryParticipants(filter) {
-    const res = await testUtils.getWithRoles(
+    const res = await testUtils.getWithUser(
       `/api/participants/?filter={"where":${encodeURIComponent(JSON.stringify(filter))},"skip":0,"limit":20}`,
-      ['registryUser']
+      user
     );
     testUtils.expectStatus(res.status, 200);
     return res;

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -3,6 +3,7 @@ import Promise from 'bluebird';
 import _ from 'lodash';
 import { expect } from 'chai';
 import { models } from '../../src/server/models';
+import request from 'supertest';
 
 export function loginUser(username, userpass) {
   userpass = userpass || 'salasana';
@@ -86,4 +87,13 @@ export function find(modelName, whereClause, includeClause) {
   const what = { where: whereClause, include: includeClause };
   const find = Promise.promisify(app.models[modelName].find, { context: app.models[modelName] });
   return find(what);
+}
+
+export function getWithRoles(path, roleNames) {
+  return createUserAndGetAccessToken(roleNames)
+    .then(token => request(app).get(path).set('Authorization', token.id));
+}
+
+export function expectStatus(status, expectedStatus) {
+  expect(status).to.equal(expectedStatus, `Expected HTTP status of ${expectedStatus}, got ${status}`);
 }

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -97,21 +97,6 @@ export function find(modelName, whereClause, includeClause) {
   return find(what);
 }
 
-export function getWithRoles(path, roleNames) {
-  return createUserAndGetAccessToken(roleNames)
-    .then(token => request(app).get(path).set('Authorization', token.id));
-}
-
-export function postWithRoles(path, roleNames, data) {
-  return createUserAndGetAccessToken(roleNames)
-    .then(token => request(app).post(path).set('Authorization', token.id).send(data));
-}
-
-export function deleteWithRoles(path, roleNames) {
-  return createUserAndGetAccessToken(roleNames)
-    .then(token => request(app).delete(path).set('Authorization', token.id));
-}
-
 export async function getWithUser(path, user) {
   const token = await user.createAccessToken(1000);
   return request(app).get(path).set('Authorization', token.id);

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -103,6 +103,11 @@ export function postWithRoles(path, roleNames, data) {
     .then(token => request(app).post(path).set('Authorization', token.id).send(data));
 }
 
+export async function postWithUser(path, user, data) {
+  const token = await user.createAccessToken(1000);
+  return request(app).post(path).set('Authorization', token.id).send(data);
+}
+
 export function expectStatus(status, expectedStatus) {
   expect(status).to.equal(expectedStatus, `Expected HTTP status of ${expectedStatus}, got ${status}`);
 }

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -103,6 +103,11 @@ export function postWithRoles(path, roleNames, data) {
     .then(token => request(app).post(path).set('Authorization', token.id).send(data));
 }
 
+export async function getWithUser(path, user) {
+  const token = await user.createAccessToken(1000);
+  return request(app).get(path).set('Authorization', token.id);
+}
+
 export async function postWithUser(path, user, data) {
   const token = await user.createAccessToken(1000);
   return request(app).post(path).set('Authorization', token.id).send(data);

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -107,6 +107,11 @@ export function postWithRoles(path, roleNames, data) {
     .then(token => request(app).post(path).set('Authorization', token.id).send(data));
 }
 
+export function deleteWithRoles(path, roleNames) {
+  return createUserAndGetAccessToken(roleNames)
+    .then(token => request(app).delete(path).set('Authorization', token.id));
+}
+
 export async function getWithUser(path, user) {
   const token = await user.createAccessToken(1000);
   return request(app).get(path).set('Authorization', token.id);

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -5,6 +5,9 @@ import { expect } from 'chai';
 import { models } from '../../src/server/models';
 import request from 'supertest';
 
+// Counter for generating e.g. unique users automatically
+let uniqueIdCounter = 1;
+
 export function loginUser(username, userpass) {
   userpass = userpass || 'salasana';
   const promiseUserLogin = Promise.promisify(app.models.RegistryUser.login, { context: app.models.RegistryUser });
@@ -45,10 +48,11 @@ function addRolesToUser(roles, user) {
 }
 
 export function createUserAndGetAccessToken(roles, overrides) {
+  uniqueIdCounter++;
   const userData = {
-    'username': 'testuser',
-    'memberNumber': '7654321',
-    'email': 'testi@example.org',
+    'username': `testuser${uniqueIdCounter}`,
+    'memberNumber': String(100000 + uniqueIdCounter),
+    'email': `test${uniqueIdCounter}@example.org`,
     'password': 'salasana',
     'firstName': 'Testi',
     'lastName': 'Testailija',

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -122,6 +122,11 @@ export async function postWithUser(path, user, data) {
   return request(app).post(path).set('Authorization', token.id).send(data);
 }
 
+export async function deleteWithUser(path, user) {
+  const token = await user.createAccessToken(1000);
+  return request(app).delete(path).set('Authorization', token.id);
+}
+
 export function expectStatus(status, expectedStatus) {
   expect(status).to.equal(expectedStatus, `Expected HTTP status of ${expectedStatus}, got ${status}`);
 }

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -26,7 +26,18 @@ export function createFixtureSequelize(modelName, fixture) {
   return models[modelName].bulkCreate(fixture);
 }
 
-export function createUserWithRoles(rolesToAdd, userData) {
+export function createUserWithRoles(rolesToAdd, overrides) {
+  uniqueIdCounter++;
+  const userData = {
+    'username': `testuser${uniqueIdCounter}`,
+    'memberNumber': String(100000 + uniqueIdCounter),
+    'email': `test${uniqueIdCounter}@example.org`,
+    'password': 'salasana',
+    'firstName': 'Testi',
+    'lastName': 'Testailija',
+    'phoneNumber': 'n/a',
+  };
+  Object.assign(userData, overrides);
   return Promise.join(
     getRolesByName(rolesToAdd),
     createFixture('RegistryUser', userData),
@@ -48,18 +59,7 @@ function addRolesToUser(roles, user) {
 }
 
 export function createUserAndGetAccessToken(roles, overrides) {
-  uniqueIdCounter++;
-  const userData = {
-    'username': `testuser${uniqueIdCounter}`,
-    'memberNumber': String(100000 + uniqueIdCounter),
-    'email': `test${uniqueIdCounter}@example.org`,
-    'password': 'salasana',
-    'firstName': 'Testi',
-    'lastName': 'Testailija',
-    'phoneNumber': 'n/a',
-  };
-  Object.assign(userData, overrides);
-  return createUserWithRoles(roles, userData).then(() => loginUser(userData.username, userData.password));
+  return createUserWithRoles(roles, overrides).then(user => user.createAccessToken(1000));
 }
 
 export function deleteFixtureIfExists(modelName, id) {

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -98,6 +98,11 @@ export function getWithRoles(path, roleNames) {
     .then(token => request(app).get(path).set('Authorization', token.id));
 }
 
+export function postWithRoles(path, roleNames, data) {
+  return createUserAndGetAccessToken(roleNames)
+    .then(token => request(app).post(path).set('Authorization', token.id).send(data));
+}
+
 export function expectStatus(status, expectedStatus) {
   expect(status).to.equal(expectedStatus, `Expected HTTP status of ${expectedStatus}, got ${status}`);
 }

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -23,7 +23,11 @@ export function createFixture(modelName, fixture) {
 }
 
 export function createFixtureSequelize(modelName, fixture) {
-  return models[modelName].bulkCreate(fixture);
+  if (Array.isArray(fixture)) {
+    return models[modelName].bulkCreate(fixture);
+  } else {
+    return models[modelName].create(fixture);
+  }
 }
 
 export function createUserWithRoles(rolesToAdd, overrides) {


### PR DESCRIPTION
Removes auth implementation details from tests to make it easier to change the auth implementation later. Tests that test technical implementation of the authentication logic have been left as is.

Apologies for the monter PR :(